### PR TITLE
Bump to 1.0.1

### DIFF
--- a/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
+++ b/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1")]
+[assembly: AssemblyFileVersion("1.0.1")]


### PR DESCRIPTION
Only real change is that we're now using Newtonsoft.Json v6 (was on v9 before, but this was causing LMS issues).