### PR TITLE
I just... don't even.

### DIFF
--- a/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
+++ b/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1")]
-[assembly: AssemblyFileVersion("1.0.1")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]


### PR DESCRIPTION
For some reason this could be fetched as 1.0.1, but VS was all like, "Oh v1.0.1? did you mean v1.0.1.0? No? Too bad going to to try to use it anyway. [10 seconds later] WHERE IS V1.0.1.0 I CANNOT FIND V1.0.1.0 AND I AM SCARED."

So I guess we'll use major.minor.patch.0 instead, to placate VS.