### PR TITLE
Adding extension methods and tests

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -8,6 +8,20 @@ namespace D2L.Hypermedia.Siren.Tests {
 	[TestFixture]
 	public class SirenActionTests {
 
+		private ISirenAction GetAction() {
+			ISirenAction action = new SirenAction(
+					name: "action-name",
+					href: new Uri( "http://example.com" ),
+					fields: new[] {
+						new SirenField( name: "field1", @class: new [] { "class" }, type: "text/html" ),
+						new SirenField( name: "field2", @class: new [] { "class" }, type: "text/html" ),
+						new SirenField( name: "field3", @class: new [] { "not-class" }, type: "text/xml" ),
+					}
+				);
+
+			return action;
+		}
+
 		[Test]
 		public void SirenAction_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 
@@ -54,6 +68,37 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.AreEqual( 1, action.Fields.ToList().Count );
 		}
 
+		[Test]
+		public void SirenAction_TryGetFieldByName_ReturnsCorrectField() {
+			ISirenField field;
+			Assert.IsFalse( GetAction().TryGetFieldByName( "foo", out field ) );
+			Assert.IsNull( field );
+
+			Assert.IsTrue( GetAction().TryGetFieldByName( "field1", out field ) );
+			Assert.AreEqual( "field1", field.Name );
+		}
+
+		[Test]
+		public void SirenAction_TryGetFieldByClass_ReturnsCorrectField() {
+			ISirenField field;
+			Assert.IsFalse( GetAction().TryGetFieldByClass( "foo", out field ) );
+			Assert.IsNull( field );
+
+			Assert.IsTrue( GetAction().TryGetFieldByClass( "class", out field ) );
+			Assert.Contains( "class", field.Class );
+			Assert.AreEqual( "field1", field.Name );
+		}
+
+		[Test]
+		public void SirenAction_TryGetFieldByType_ReturnsCorrectField() {
+			ISirenField field;
+			Assert.IsFalse( GetAction().TryGetFieldByType( "foo", out field ) );
+			Assert.IsNull( field );
+
+			Assert.IsTrue( GetAction().TryGetFieldByType( "text/xml", out field ) );
+			Assert.AreEqual( "text/xml", field.Type );
+			Assert.AreEqual( "field3", field.Name );
+		}
 	}
 
 }

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
@@ -8,6 +8,30 @@ namespace D2L.Hypermedia.Siren.Tests {
 	[TestFixture]
 	public class SirenEntityTests {
 
+		private ISirenEntity GetEntity() {
+			ISirenEntity entity = new SirenEntity(
+					rel: new [] { "rel" },
+					@class: new [] { "class" },
+					links: new [] {
+						new SirenLink( rel: new[] { "self" }, href: new Uri( "http://example.com" ), @class: new [] { "class" }, type: "text/html", title: "link1" ),
+						new SirenLink( rel: new[] { "next" }, href: new Uri( "http://example.com" ), @class: new [] { "class" }, type: "text/html", title: "link2" ),
+						new SirenLink( rel: new[] { "next" }, href: new Uri( "http://example.com" ), @class: new [] { "not-class" }, type: "text/html", title: "link3" )
+					},
+					actions: new [] {
+						new SirenAction( name: "action1", href: new Uri( "http://example.com" ), @class: new[] { "class" } ),
+						new SirenAction( name: "action2", href: new Uri( "http://example.com" ), @class: new[] { "class" } ),
+						new SirenAction( name: "action3", href: new Uri( "http://example.com" ), @class: new[] { "not-class" } )
+					},
+					entities: new [] {
+						new SirenEntity( rel: new [] { "child" }, @class: new [] { "class" }, type: "text/html", title: "entity1" ),
+						new SirenEntity( rel: new [] { "child" }, @class: new [] { "class" }, type: "text/html", title: "entity2" ),
+						new SirenEntity( rel: new [] { "not-child" }, @class: new [] { "class" }, type: "text/xml", title: "entity3" )
+					}
+				);
+
+			return entity;
+		}
+
 		[Test]
 		public void SirenEntity_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 
@@ -37,7 +61,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 					foo = "bar"
 				},
 				links: new[] {
-					new SirenLink( rel: new [] { "foo" }, href: new Uri( "http://example.com" ) )
+					new SirenLink( rel: new[] { "self" }, href: new Uri( "http://example.com" ), @class: new[] { "class" } )
 				},
 				rel: new[] { "organization" },
 				@class: new[] { "some-class" },
@@ -45,7 +69,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 					new SirenEntity()
 				},
 				actions: new[] {
-					new SirenAction( name: "action", href: new Uri( "http://example.com/2" ) )
+					new SirenAction( name: "action-name", href: new Uri( "http://example.com" ), @class: new[] { "class" } )
 				},
 				title: "Entity title",
 				href: new Uri( "http://example.com/3" ),
@@ -64,6 +88,82 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.AreEqual( "http://example.com/3", entity.Href.ToString() );
 			Assert.AreEqual( "text/html", entity.Type );
 
+		}
+
+		[Test]
+		public void SirenEntity_TryGetActionByName_ReturnsCorrectAction() {
+			ISirenAction action;
+			Assert.IsFalse( GetEntity().TryGetActionByName( "foo", out action ) );
+			Assert.IsNull( action );
+
+			Assert.IsTrue( GetEntity().TryGetActionByName( "action2", out action ) );
+			Assert.AreEqual( "action2", action.Name );
+		}
+
+		[Test]
+		public void SirenEntity_TryGetActionByClass_ReturnsCorrectAction() {
+			ISirenAction action;
+			Assert.IsFalse( GetEntity().TryGetActionByClass( "foo", out action ) );
+			Assert.IsNull( action );
+
+			Assert.IsTrue( GetEntity().TryGetActionByClass( "class", out action ) );
+			Assert.Contains( "class", action.Class );
+			Assert.AreEqual( "action1", action.Name );
+		}
+
+		[Test]
+		public void SirenEntity_TryGetLinkByRel_ReturnsCorrectLink() {
+			ISirenLink link;
+			Assert.IsFalse( GetEntity().TryGetLinkByRel( "foo", out link ) );
+			Assert.IsNull( link );
+
+			Assert.IsTrue( GetEntity().TryGetLinkByRel( "next", out link ) );
+			Assert.Contains( "next", link.Rel );
+			Assert.AreEqual( "link2", link.Title );
+		}
+
+		[Test]
+		public void SirenEntity_TryGetLinkByClass_ReturnsCorrectLink() {
+			ISirenLink link;
+			Assert.IsFalse( GetEntity().TryGetLinkByClass( "foo", out link ) );
+			Assert.IsNull( link );
+
+			Assert.IsTrue( GetEntity().TryGetLinkByClass( "class", out link ) );
+			Assert.Contains( "class", link.Class );
+			Assert.AreEqual( "link1", link.Title );
+		}
+
+		[Test]
+		public void SirenEntity_TryGetSubEntityByRel_ReturnsCorrectEntity() {
+			ISirenEntity entity;
+			Assert.IsFalse( GetEntity().TryGetSubEntityByClass( "foo", out entity ) );
+			Assert.IsNull( entity );
+
+			Assert.IsTrue( GetEntity().TryGetSubEntityByClass( "class", out entity ) );
+			Assert.Contains( "class", entity.Class );
+			Assert.AreEqual( "entity1", entity.Title );
+		}
+
+		[Test]
+		public void SirenEntity_TryGetSubEntityByClass_ReturnsCorrectEntity() {
+			ISirenEntity entity;
+			Assert.IsFalse( GetEntity().TryGetSubEntityByRel( "foo", out entity ) );
+			Assert.IsNull( entity );
+
+			Assert.IsTrue( GetEntity().TryGetSubEntityByRel( "child", out entity ) );
+			Assert.Contains( "child", entity.Rel );
+			Assert.AreEqual( "entity1", entity.Title );
+		}
+
+		[Test]
+		public void SirenEntity_TryGetSubEntityByType_ReturnsCorrectEntity() {
+			ISirenEntity entity;
+			Assert.IsFalse( GetEntity().TryGetSubEntityByType( "foo", out entity ) );
+			Assert.IsNull( entity );
+
+			Assert.IsTrue( GetEntity().TryGetSubEntityByType( "text/xml", out entity ) );
+			Assert.AreEqual( "text/xml", entity.Type );
+			Assert.AreEqual( "entity3", entity.Title );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
+++ b/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
@@ -44,6 +44,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SirenActionExtensions.cs" />
+    <Compile Include="SirenEntityExtensions.cs" />
     <Compile Include="ISirenAction.cs" />
     <Compile Include="ISirenEntity.cs" />
     <Compile Include="ISirenField.cs" />

--- a/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
+++ b/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/D2L.Hypermedia.Siren/SirenActionExtensions.cs
+++ b/D2L.Hypermedia.Siren/SirenActionExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace D2L.Hypermedia.Siren {
+
+	public static class SirenActionExtensions {
+
+		public static bool TryGetFieldByName(
+				this ISirenAction @this,
+				string name,
+				out ISirenField field
+		) {
+			field = @this.Fields.FirstOrDefault( f => f.Name.Equals( name ) );
+			return field != default( ISirenField );
+		}
+
+		public static bool TryGetFieldByClass(
+				this ISirenAction @this,
+				string @class,
+				out ISirenField field
+		) {
+			field = @this.FieldsByClass( @class ).FirstOrDefault();
+			return field != default( ISirenField );
+		}
+
+		public static bool TryGetFieldByType(
+				this ISirenAction @this,
+				string type,
+				out ISirenField field
+		) {
+			field = @this.FieldsByType( type ).FirstOrDefault();
+			return field != default( ISirenField );
+		}
+
+		public static IEnumerable<ISirenField> FieldsByClass(
+				this ISirenAction @this,
+				string @class
+		) {
+			return @this.Fields.Where( field => field.Class.Contains( @class ) );
+		}
+
+		public static IEnumerable<ISirenField> FieldsByType(
+				this ISirenAction @this,
+				string type
+		) {
+			return @this.Fields.Where( field => field.Type.Equals( type ) );
+		}
+
+	}
+
+}

--- a/D2L.Hypermedia.Siren/SirenEntityExtensions.cs
+++ b/D2L.Hypermedia.Siren/SirenEntityExtensions.cs
@@ -1,0 +1,131 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace D2L.Hypermedia.Siren {
+
+	public static class SirenEntityExtensions {
+
+		public static bool TryGetActionByName(
+				this ISirenEntity @this,
+				string name,
+				out ISirenAction action
+		) {
+			action = @this.Actions.FirstOrDefault( a => a.Name.Equals( name ) );
+			return action != default( ISirenAction );
+		}
+
+		public static bool TryGetActionByClass(
+				this ISirenEntity @this,
+				string @class,
+				out ISirenAction action
+		) {
+			action = @this.ActionsByClass( @class ).FirstOrDefault();
+			return action != default( ISirenAction );
+		}
+
+		public static bool TryGetLinkByRel(
+				this ISirenEntity @this,
+				string rel,
+				out ISirenLink link
+		) {
+			link = @this.LinksByRel( rel ).FirstOrDefault();
+			return link != default( ISirenLink );
+		}
+
+		public static bool TryGetLinkByClass(
+				this ISirenEntity @this,
+				string @class,
+				out ISirenLink link
+		) {
+			link = @this.LinksByClass( @class ).FirstOrDefault();
+			return link != default( ISirenLink );
+		}
+
+		public static bool TryGetLinkByType(
+				this ISirenEntity @this,
+				string type,
+				out ISirenLink link
+		) {
+			link = @this.LinksByType( type ).FirstOrDefault();
+			return link != default( ISirenLink );
+		}
+
+		public static bool TryGetSubEntityByRel(
+				this ISirenEntity @this,
+				string rel,
+				out ISirenEntity entity
+		) {
+			entity = @this.SubEntitiesByRel( rel ).FirstOrDefault();
+			return entity != default( ISirenEntity );
+		}
+
+		public static bool TryGetSubEntityByClass(
+				this ISirenEntity @this,
+				string @class,
+				out ISirenEntity entity
+		) {
+			entity = @this.SubEntitiesByClass( @class ).FirstOrDefault();
+			return entity != default( ISirenEntity );
+		}
+
+		public static bool TryGetSubEntityByType(
+				this ISirenEntity @this,
+				string type,
+				out ISirenEntity entity
+		) {
+			entity = @this.SubEntitiesByType( type ).FirstOrDefault();
+			return entity != default( ISirenEntity );
+		}
+
+		public static IEnumerable<ISirenAction> ActionsByClass(
+				this ISirenEntity @this,
+				string @class
+		) {
+			return @this.Actions.Where( action => action.Class.Contains( @class ) );
+		}
+
+		public static IEnumerable<ISirenLink> LinksByRel(
+				this ISirenEntity @this,
+				string rel
+		) {
+			return @this.Links.Where( link => link.Rel.Contains( rel ) );
+		}
+
+		public static IEnumerable<ISirenLink> LinksByClass(
+				this ISirenEntity @this,
+				string @class
+		) {
+			return @this.Links.Where( link => link.Class.Contains( @class ) );
+		}
+
+		public static IEnumerable<ISirenLink> LinksByType(
+				this ISirenEntity @this,
+				string type
+		) {
+			return @this.Links.Where( link => link.Type.Equals( type ) );
+		}
+
+		public static IEnumerable<ISirenEntity> SubEntitiesByRel(
+				this ISirenEntity @this,
+				string rel
+		) {
+			return @this.Entities.Where( entity => entity.Rel.Contains( rel ) );
+		}
+
+		public static IEnumerable<ISirenEntity> SubEntitiesByClass(
+				this ISirenEntity @this,
+				string @class
+		) {
+			return @this.Entities.Where( entity => entity.Class.Contains( @class ) );
+		}
+
+		public static IEnumerable<ISirenEntity> SubEntitiesByType(
+				this ISirenEntity @this,
+				string type
+		) {
+			return @this.Entities.Where( entity => entity.Type.Equals( type ) );
+		}
+
+	}
+
+}


### PR DESCRIPTION
These allow for a bit more fluent of an interface when dealing with the various ISiren* objects. For example, one can do `ISirenEntity.TryGetLinkByRel("self", out link)` if you want to get the self link of an entity. To skip the Try-ness, could also just do `ISirenEntity.LinksByRel("self")[0]`.

This change is approximately to add what's available in [node-siren-parser](https://www.npmjs.com/package/siren-parser), ish.