### PR TITLE
Don't serialize empty sets

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -24,7 +24,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 
 		[Test]
 		public void SirenAction_Serialized_DoesNotIncludeOptionalParametersIfNull() {
-
 			ISirenAction sirenAction = new SirenAction(
 					name: "foo",
 					href: new Uri( "http://example.com" ) );
@@ -34,17 +33,15 @@ namespace D2L.Hypermedia.Siren.Tests {
 
 			Assert.AreEqual( "foo", action.Name );
 			Assert.AreEqual( "http://example.com/", action.Href.ToString() );
-			Assert.IsNull( action.Class );
+			Assert.IsEmpty( action.Class );
 			Assert.IsNull( action.Method );
 			Assert.IsNull( action.Title );
 			Assert.IsNull( action.Type );
-			Assert.IsNull( action.Fields );
-
+			Assert.IsEmpty( action.Fields );
 		}
 
 		[Test]
 		public void SirenAction_DeserializesCorrectly() {
-
 			ISirenAction sirenAction = new SirenAction(
 				name: "foo",
 				href: new Uri( "http://example.com" ),
@@ -66,6 +63,27 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.AreEqual( "Some action", action.Title );
 			Assert.AreEqual( "text/html", action.Type );
 			Assert.AreEqual( 1, action.Fields.ToList().Count );
+		}
+
+		[Test]
+		public void SirenAction_Serialize_ExcludesClassAndFieldsIfEmpty() {
+			ISirenAction action = new SirenAction(
+					name: "foo",
+					href: new Uri( "http://example.com" ),
+					@class: new [] { "bar" },
+					fields: new [] { new SirenField( "baz" ) }
+				);
+			string serialized = JsonConvert.SerializeObject( action );
+			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
+			Assert.GreaterOrEqual( serialized.IndexOf( "fields", StringComparison.Ordinal ), 0 );
+
+			action = new SirenAction(
+					name: "foo",
+					href: new Uri( "http://example.com" )
+				);
+			serialized = JsonConvert.SerializeObject( action );
+			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
+			Assert.AreEqual( -1, serialized.IndexOf( "fields", StringComparison.Ordinal ) );
 		}
 
 		[Test]

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
@@ -34,46 +34,44 @@ namespace D2L.Hypermedia.Siren.Tests {
 
 		[Test]
 		public void SirenEntity_Serialized_DoesNotIncludeOptionalParametersIfNull() {
-
 			ISirenEntity sirenEntity = new SirenEntity();
 
 			string serialized = JsonConvert.SerializeObject( sirenEntity );
 
 			ISirenEntity entity = JsonConvert.DeserializeObject<SirenEntity>( serialized );
 
-			Assert.IsNull( entity.Class );
+			Assert.IsEmpty( entity.Class );
 			Assert.IsNull( entity.Properties );
-			Assert.IsNull( entity.Entities );
-			Assert.IsNull( entity.Links );
-			Assert.IsNull( entity.Actions );
+			Assert.IsEmpty( entity.Entities );
+			Assert.IsEmpty( entity.Links );
+			Assert.IsEmpty( entity.Actions );
 			Assert.IsNull( entity.Title );
-			Assert.IsNull( entity.Rel );
+			Assert.IsEmpty( entity.Rel );
 			Assert.IsNull( entity.Href );
 			Assert.IsNull( entity.Type );
-
 		}
 
 		[Test]
 		public void SirenEntity_DeserializesCorrectly() {
-
 			ISirenEntity sirenEntity = new SirenEntity(
-				properties: new {
-					foo = "bar"
-				},
-				links: new[] {
-					new SirenLink( rel: new[] { "self" }, href: new Uri( "http://example.com" ), @class: new[] { "class" } )
-				},
-				rel: new[] { "organization" },
-				@class: new[] { "some-class" },
-				entities: new[] {
-					new SirenEntity()
-				},
-				actions: new[] {
-					new SirenAction( name: "action-name", href: new Uri( "http://example.com" ), @class: new[] { "class" } )
-				},
-				title: "Entity title",
-				href: new Uri( "http://example.com/3" ),
-				type: "text/html" );
+					properties: new {
+						foo = "bar"
+					},
+					links: new[] {
+						new SirenLink( rel: new[] { "self" }, href: new Uri( "http://example.com" ), @class: new[] { "class" } )
+					},
+					rel: new[] { "organization" },
+					@class: new[] { "some-class" },
+					entities: new[] {
+						new SirenEntity()
+					},
+					actions: new[] {
+						new SirenAction( name: "action-name", href: new Uri( "http://example.com" ), @class: new[] { "class" } )
+					},
+					title: "Entity title",
+					href: new Uri( "http://example.com/3" ),
+					type: "text/html"
+				);
 
 			string serialized = JsonConvert.SerializeObject( sirenEntity );
 			ISirenEntity entity = JsonConvert.DeserializeObject<SirenEntity>( serialized );
@@ -87,7 +85,37 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.AreEqual( "Entity title", entity.Title );
 			Assert.AreEqual( "http://example.com/3", entity.Href.ToString() );
 			Assert.AreEqual( "text/html", entity.Type );
+		}
 
+		[Test]
+		public void SirenEntity_Serialize_ExcludesRelClassEntitiesLinksAndActionsIfEmpty() {
+			ISirenEntity entity = new SirenEntity(
+					@class: new[] { "foo" },
+					rel: new[] { "bar" },
+					entities: new[] {
+						new SirenEntity()
+					},
+					links: new[] {
+						new SirenLink( rel: new[] { "self" }, href: new Uri( "http://example.com" ), @class: new[] { "class" } )
+					},
+					actions: new[] {
+						new SirenAction( name: "action-name", href: new Uri( "http://example.com" ), @class: new[] { "class" } )
+					}
+				);
+			string serialized = JsonConvert.SerializeObject( entity );
+			Assert.GreaterOrEqual( serialized.IndexOf( "rel", StringComparison.Ordinal ), -1 );
+			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), -1 );
+			Assert.GreaterOrEqual( serialized.IndexOf( "entities", StringComparison.Ordinal ), -1 );
+			Assert.GreaterOrEqual( serialized.IndexOf( "links", StringComparison.Ordinal ), -1 );
+			Assert.GreaterOrEqual( serialized.IndexOf( "actions", StringComparison.Ordinal ), -1 );
+
+			entity = new SirenEntity();
+			serialized = JsonConvert.SerializeObject( entity );
+			Assert.AreEqual( -1, serialized.IndexOf( "rel", StringComparison.Ordinal ) );
+			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
+			Assert.AreEqual( -1, serialized.IndexOf( "entities", StringComparison.Ordinal ) );
+			Assert.AreEqual( -1, serialized.IndexOf( "links", StringComparison.Ordinal ) );
+			Assert.AreEqual( -1, serialized.IndexOf( "actions", StringComparison.Ordinal ) );
 		}
 
 		[Test]

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace D2L.Hypermedia.Siren.Tests {
@@ -8,23 +9,20 @@ namespace D2L.Hypermedia.Siren.Tests {
 
 		[Test]
 		public void SirenField_Serialized_DoesNotIncludeOptionalParametersIfNull() {
-
 			ISirenField sirenField = new SirenField( name: "foo" );
 
 			string serialized = JsonConvert.SerializeObject( sirenField );
 			ISirenField field = JsonConvert.DeserializeObject<SirenField>( serialized );
 
 			Assert.AreEqual( "foo", field.Name );
-			Assert.IsNull( field.Class );
+			Assert.IsEmpty( field.Class );
 			Assert.IsNull( field.Type );
 			Assert.IsNull( field.Value );
 			Assert.IsNull( field.Title );
-
 		}
 
 		[Test]
 		public void SirenField_DeserializesCorrectly() {
-
 			ISirenField sirenField = new SirenField(
 				name: "foo",
 				@class: new[] { "bar" },
@@ -40,7 +38,22 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.AreEqual( "number", field.Type );
 			Assert.AreEqual( 1, int.Parse( field.Value.ToString() ) );
 			Assert.AreEqual( "Some field", field.Title );
+		}
 
+		[Test]
+		public void SirenField_Serialize_ExcludesClassIfEmpty() {
+			ISirenField field = new SirenField(
+					name: "foo",
+					@class: new[] { "bar" }
+				);
+			string serialized = JsonConvert.SerializeObject( field );
+			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
+
+			field = new SirenField(
+					name: "foo"
+				);
+			serialized = JsonConvert.SerializeObject( field );
+			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
@@ -9,7 +9,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 
 		[Test]
 		public void SirenLink_Serialized_DoesNotIncludeOptionalParametersIfNull() {
-
 			ISirenLink sirenLink = new SirenLink(
 					rel: new[] { "foo" },
 					href: new Uri( "http://example.com" ) );
@@ -20,15 +19,13 @@ namespace D2L.Hypermedia.Siren.Tests {
 
 			Assert.AreEqual( "foo", link.Rel[0] );
 			Assert.AreEqual( "http://example.com/", link.Href.ToString() );
-			Assert.IsNull( link.Class );
+			Assert.IsEmpty( link.Class );
 			Assert.IsNull( link.Type );
 			Assert.IsNull( link.Title );
-
 		}
 
 		[Test]
 		public void SirenLink_DeserializesCorrectly() {
-
 			ISirenLink sirenLink = new SirenLink(
 					rel: new[] { "foo" },
 					href: new Uri( "http://example.com" ),
@@ -45,7 +42,24 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.Contains( "foo", link.Class );
 			Assert.AreEqual( "Link title", link.Title );
 			Assert.AreEqual( "text/html", link.Type );
+		}
 
+		[Test]
+		public void SirenLink_Serialize_ExcludesClassIfEmptyArray() {
+			ISirenLink link = new SirenLink(
+					rel: new [] { "foo" },
+					href: new Uri( "http://example.com" ),
+					@class: new [] { "bar" }
+				);
+			string serialized = JsonConvert.SerializeObject( link );
+			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
+
+			link = new SirenLink(
+					rel: new [] { "foo" },
+					href: new Uri( "http://example.com" )
+				);
+			serialized = JsonConvert.SerializeObject( link );
+			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 		}
 	}
 

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
 
 	public class SirenAction : ISirenAction {
 
+		private readonly string m_name;
+		private readonly string[] m_class;
 		private readonly IEnumerable<ISirenField> m_fields;
 		private readonly string m_type;
 		private readonly string m_title;
 		private readonly Uri m_href;
 		private readonly string m_method;
-		private readonly string[] m_class;
-		private readonly string m_name;
 
 		public SirenAction(
 			string name,
@@ -24,48 +25,56 @@ namespace D2L.Hypermedia.Siren {
 			IEnumerable<ISirenField> fields = null
 		) {
 			m_name = name;
-			m_class = @class;
+			m_class = @class ?? new string[0];
 			m_method = method;
 			m_href = href;
 			m_title = title;
 			m_type = type;
-			m_fields = fields;
+			m_fields = fields ?? new List<ISirenField>();
 		}
 
 		[JsonProperty( "name" )]
-		string ISirenAction.Name {
+		public string Name {
 			get { return m_name; }
 		}
 
 		[JsonProperty( "class", NullValueHandling = NullValueHandling.Ignore )]
-		string[] ISirenAction.Class {
+		public string[] Class {
 			get { return m_class; }
 		}
 
 		[JsonProperty( "method", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenAction.Method {
+		public string Method {
 			get { return m_method; }
 		}
 
 		[JsonProperty( "href" )]
-		Uri ISirenAction.Href {
+		public Uri Href {
 			get { return m_href; }
 		}
 
 		[JsonProperty( "title", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenAction.Title {
+		public string Title {
 			get { return m_title; }
 		}
 
 		[JsonProperty( "type", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenAction.Type {
+		public string Type {
 			get { return m_type; }
 		}
 
 		[JsonProperty( "fields", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof( HypermediaFieldConverter ) )]
-		IEnumerable<ISirenField> ISirenAction.Fields {
+		[JsonConverter( typeof(HypermediaFieldConverter) )]
+		public IEnumerable<ISirenField> Fields {
 			get { return m_fields; }
+		}
+
+		public bool ShouldSerializeClass() {
+			return Class.Length > 0;
+		}
+
+		public bool ShouldSerializeFields() {
+			return Fields.Any();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
 
 	public class SirenEntity : ISirenEntity {
 
-		private readonly string[] m_class;
-		private readonly dynamic m_properties;
 		private readonly string m_type;
 		private readonly Uri m_href;
 		private readonly string[] m_rel;
@@ -15,6 +14,8 @@ namespace D2L.Hypermedia.Siren {
 		private readonly IEnumerable<ISirenAction> m_actions;
 		private readonly IEnumerable<ISirenLink> m_links;
 		private readonly IEnumerable<ISirenEntity> m_entities;
+		private readonly dynamic m_properties;
+		private readonly string[] m_class;
 
 		public SirenEntity(
 			string[] rel = null,
@@ -27,63 +28,83 @@ namespace D2L.Hypermedia.Siren {
 			Uri href = null,
 			string type = null
 		) {
-			m_rel = rel;
-			m_class = @class;
+			m_rel = rel ?? new string[0];
+			m_class = @class ?? new string[0];
 			m_properties = properties;
-			m_entities = entities;
-			m_links = links;
-			m_actions = actions;
+			m_entities = entities ?? new List<ISirenEntity>();
+			m_links = links ?? new List<ISirenLink>();
+			m_actions = actions ?? new List<ISirenAction>();
 			m_title = title;
 			m_href = href;
 			m_type = type;
 		}
 
 		[JsonProperty( "class", NullValueHandling = NullValueHandling.Ignore )]
-		string[] ISirenEntity.Class {
+		public string[] Class {
 			get { return m_class; }
 		}
 
 		[JsonProperty( "properties", NullValueHandling = NullValueHandling.Ignore )]
-		dynamic ISirenEntity.Properties {
+		public dynamic Properties {
 			get { return m_properties; }
 		}
 
 		[JsonProperty( "entities", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof( HypermediaEntityConverter ) )]
-		IEnumerable<ISirenEntity> ISirenEntity.Entities {
+		[JsonConverter( typeof(HypermediaEntityConverter) )]
+		public IEnumerable<ISirenEntity> Entities {
 			get { return m_entities; }
 		}
 
 		[JsonProperty( "links", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof( HypermediaLinkConverter ) )]
-		IEnumerable<ISirenLink> ISirenEntity.Links {
+		[JsonConverter( typeof(HypermediaLinkConverter) )]
+		public IEnumerable<ISirenLink> Links {
 			get { return m_links; }
 		}
 
 		[JsonProperty( "actions", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof( HypermediaActionConverter ) )]
-		IEnumerable<ISirenAction> ISirenEntity.Actions {
+		[JsonConverter( typeof(HypermediaActionConverter) )]
+		public IEnumerable<ISirenAction> Actions {
 			get { return m_actions; }
 		}
 
 		[JsonProperty( "title", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenEntity.Title {
+		public string Title {
 			get { return m_title; }
 		}
 
 		[JsonProperty( "rel", NullValueHandling = NullValueHandling.Ignore )]
-		string[] ISirenEntity.Rel {
+		public string[] Rel {
 			get { return m_rel; }
 		}
 
 		[JsonProperty( "href", NullValueHandling = NullValueHandling.Ignore )]
-		Uri ISirenEntity.Href {
+		public Uri Href {
 			get { return m_href; }
 		}
 
 		[JsonProperty( "type", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenEntity.Type {
+		public string Type {
 			get { return m_type; }
+		}
+
+		public bool ShouldSerializeRel() {
+			return Rel.Length > 0;
+		}
+
+		public bool ShouldSerializeClass() {
+			return Class.Length > 0;
+		}
+
+		public bool ShouldSerializeEntities() {
+			return Entities.Any();
+		}
+
+		public bool ShouldSerializeLinks() {
+			return Links.Any();
+		}
+
+		public bool ShouldSerializeActions() {
+			return Actions.Any();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -5,11 +5,11 @@ namespace D2L.Hypermedia.Siren {
 
 	public class SirenField : ISirenField {
 
-		private readonly string m_name;
 		private readonly string m_title;
 		private readonly object m_value;
 		private readonly string m_type;
 		private readonly string[] m_class;
+		private readonly string m_name;
 
 		public SirenField(
 			string name,
@@ -19,35 +19,39 @@ namespace D2L.Hypermedia.Siren {
 			string title = null
 		) {
 			m_name = name;
-			m_class = @class;
+			m_class = @class ?? new string[0];
 			m_type = type;
 			m_value = value;
 			m_title = title;
 		}
 
 		[JsonProperty( "name" )]
-		string ISirenField.Name {
+		public string Name {
 			get { return m_name; }
 		}
 
 		[JsonProperty( "class", NullValueHandling = NullValueHandling.Ignore )]
-		string[] ISirenField.Class {
+		public string[] Class {
 			get { return m_class; }
 		}
 
 		[JsonProperty( "type", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenField.Type {
+		public string Type {
 			get { return m_type; }
 		}
 
 		[JsonProperty( "value", NullValueHandling = NullValueHandling.Ignore )]
-		object ISirenField.Value {
+		public object Value {
 			get { return m_value; }
 		}
 
 		[JsonProperty( "title", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenField.Title {
+		public string Title {
 			get { return m_title; }
+		}
+
+		public bool ShouldSerializeClass() {
+			return Class.Length > 0;
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -5,11 +5,11 @@ namespace D2L.Hypermedia.Siren {
 
 	public class SirenLink : ISirenLink {
 
-		private readonly string[] m_rel;
+		private readonly string m_type;
+		private readonly string m_title;
 		private readonly Uri m_href;
 		private readonly string[] m_class;
-		private readonly string m_title;
-		private readonly string m_type;
+		private readonly string[] m_rel;
 
 		public SirenLink(
 			string[] rel,
@@ -20,34 +20,38 @@ namespace D2L.Hypermedia.Siren {
 		) {
 			m_rel = rel;
 			m_href = href;
-			m_class = @class;
+			m_class = @class ?? new string[0];
 			m_title = title;
 			m_type = type;
 		}
 
 		[JsonProperty( "rel" )]
-		string[] ISirenLink.Rel {
+		public string[] Rel {
 			get { return m_rel; }
 		}
 
 		[JsonProperty( "class", NullValueHandling = NullValueHandling.Ignore )]
-		string[] ISirenLink.Class {
+		public string[] Class {
 			get { return m_class; }
 		}
 
 		[JsonProperty( "href" )]
-		Uri ISirenLink.Href {
+		public Uri Href {
 			get { return m_href; }
 		}
 
 		[JsonProperty( "title", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenLink.Title {
+		public string Title {
 			get { return m_title; }
 		}
 
 		[JsonProperty( "type", NullValueHandling = NullValueHandling.Ignore )]
-		string ISirenLink.Type {
+		public string Type {
 			get { return m_type; }
+		}
+
+		public bool ShouldSerializeClass() {
+			return Class.Length > 0;
 		}
 
 	}


### PR DESCRIPTION
If any property of an ISiren* is an IEnumerable, but is created with said IEnumerable being empty, don't bother serializing it. That said, when the object is instantiated, if the value is null then default to an empty IEnumerable. This allows us to still use extension methods on things that may be "null".

For example, if a SirenAction is created with no fields, any calls to theAction.Fields.Whatever will fail, since it's null. This includes things like theAction.Fields.Any(), which one would expect to always work. This default-to-empty-array-but-don't-serialize-empty-array behaviour allows for this, and also prevents serializing empty arrays pointlessly.

Probably worth noting that doing this requires using the "ShouldSerializeFoo" methods, which require fields to implicit, not explicit declarations.