### PR TITLE
Null check in extension methods

### DIFF
--- a/D2L.Hypermedia.Siren/SirenActionExtensions.cs
+++ b/D2L.Hypermedia.Siren/SirenActionExtensions.cs
@@ -10,7 +10,7 @@ namespace D2L.Hypermedia.Siren {
 				string name,
 				out ISirenField field
 		) {
-			field = @this.Fields.FirstOrDefault( f => f.Name.Equals( name ) );
+			field = @this.Fields.FirstOrDefault( f => f.Name != null && f.Name.Equals( name ) );
 			return field != default( ISirenField );
 		}
 
@@ -36,14 +36,14 @@ namespace D2L.Hypermedia.Siren {
 				this ISirenAction @this,
 				string @class
 		) {
-			return @this.Fields.Where( field => field.Class.Contains( @class ) );
+			return @this.Fields.Where( field => field.Class != null && field.Class.Contains( @class ) );
 		}
 
 		public static IEnumerable<ISirenField> FieldsByType(
 				this ISirenAction @this,
 				string type
 		) {
-			return @this.Fields.Where( field => field.Type.Equals( type ) );
+			return @this.Fields.Where( field => field.Type != null && field.Type.Equals( type ) );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenEntityExtensions.cs
+++ b/D2L.Hypermedia.Siren/SirenEntityExtensions.cs
@@ -10,7 +10,7 @@ namespace D2L.Hypermedia.Siren {
 				string name,
 				out ISirenAction action
 		) {
-			action = @this.Actions.FirstOrDefault( a => a.Name.Equals( name ) );
+			action = @this.Actions.FirstOrDefault( a => a.Name != null && a.Name.Equals( name ) );
 			return action != default( ISirenAction );
 		}
 
@@ -81,49 +81,49 @@ namespace D2L.Hypermedia.Siren {
 				this ISirenEntity @this,
 				string @class
 		) {
-			return @this.Actions.Where( action => action.Class.Contains( @class ) );
+			return @this.Actions.Where( action => action.Class != null && action.Class.Contains( @class ) );
 		}
 
 		public static IEnumerable<ISirenLink> LinksByRel(
 				this ISirenEntity @this,
 				string rel
 		) {
-			return @this.Links.Where( link => link.Rel.Contains( rel ) );
+			return @this.Links.Where( link => link.Rel != null && link.Rel.Contains( rel ) );
 		}
 
 		public static IEnumerable<ISirenLink> LinksByClass(
 				this ISirenEntity @this,
 				string @class
 		) {
-			return @this.Links.Where( link => link.Class.Contains( @class ) );
+			return @this.Links.Where( link => link.Class != null && link.Class.Contains( @class ) );
 		}
 
 		public static IEnumerable<ISirenLink> LinksByType(
 				this ISirenEntity @this,
 				string type
 		) {
-			return @this.Links.Where( link => link.Type.Equals( type ) );
+			return @this.Links.Where( link => link.Type != null && link.Type.Equals( type ) );
 		}
 
 		public static IEnumerable<ISirenEntity> SubEntitiesByRel(
 				this ISirenEntity @this,
 				string rel
 		) {
-			return @this.Entities.Where( entity => entity.Rel.Contains( rel ) );
+			return @this.Entities.Where( entity => entity.Rel != null && entity.Rel.Contains( rel ) );
 		}
 
 		public static IEnumerable<ISirenEntity> SubEntitiesByClass(
 				this ISirenEntity @this,
 				string @class
 		) {
-			return @this.Entities.Where( entity => entity.Class.Contains( @class ) );
+			return @this.Entities.Where( entity => entity.Class != null && entity.Class.Contains( @class ) );
 		}
 
 		public static IEnumerable<ISirenEntity> SubEntitiesByType(
 				this ISirenEntity @this,
 				string type
 		) {
-			return @this.Entities.Where( entity => entity.Type.Equals( type ) );
+			return @this.Entities.Where( entity => entity.Type != null && entity.Type.Equals( type ) );
 		}
 
 	}


### PR DESCRIPTION
These were throwing if, e.g., one of the links on an entity didn't have any classes and you called `.TryGetLinkByClass`.