### PR TITLE
Add ISirenSerializable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ obj
 packages
 build/*
 project.lock.json
+D2L.Hypermedia.Siren/.vs/*

--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -11,13 +11,15 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenAction_Serialized_DoesNotIncludeOptionalParametersIfNull() {
+		public void SirenAction_Serialized_DoesNotIncludeOptionalParametersIfNull(
+			[Values] bool useToJson
+		) {
 			ISirenAction sirenAction = new SirenAction(
 				name: "foo",
 				href: new Uri( "http://example.com" )
 			);
 
-			string serialized = JsonConvert.SerializeObject( sirenAction );
+			string serialized = useToJson ? sirenAction.ToJson() : JsonConvert.SerializeObject( sirenAction );
 			ISirenAction action = JsonConvert.DeserializeObject<SirenAction>( serialized );
 
 			Assert.AreEqual( "foo", action.Name );
@@ -30,7 +32,9 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenAction_DeserializesCorrectly() {
+		public void SirenAction_DeserializesCorrectly(
+			[Values] bool useToJson
+		) {
 			ISirenAction sirenAction = new SirenAction(
 				name: "foo",
 				href: new Uri( "http://example.com" ),
@@ -43,7 +47,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 				}
 			);
 
-			string serialized = JsonConvert.SerializeObject( sirenAction );
+			string serialized = useToJson ? sirenAction.ToJson() : JsonConvert.SerializeObject( sirenAction );
 			ISirenAction action = JsonConvert.DeserializeObject<SirenAction>( serialized );
 
 			Assert.AreEqual( "foo", action.Name );
@@ -56,14 +60,16 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenAction_Serialize_ExcludesClassAndFieldsIfEmpty() {
+		public void SirenAction_Serialize_ExcludesClassAndFieldsIfEmpty(
+			[Values] bool useToJson
+		) {
 			ISirenAction action = new SirenAction(
 				name: "foo",
 				href: new Uri( "http://example.com" ),
 				@class: new [] { "bar" },
 				fields: new [] { new SirenField( "baz" ) }
 			);
-			string serialized = JsonConvert.SerializeObject( action );
+			string serialized = useToJson ? action.ToJson() : JsonConvert.SerializeObject( action );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
 			Assert.GreaterOrEqual( serialized.IndexOf( "fields", StringComparison.Ordinal ), 0 );
 
@@ -71,7 +77,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 				name: "foo",
 				href: new Uri( "http://example.com" )
 			);
-			serialized = JsonConvert.SerializeObject( action );
+			serialized = useToJson ? action.ToJson() : JsonConvert.SerializeObject( action );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 			Assert.AreEqual( -1, serialized.IndexOf( "fields", StringComparison.Ordinal ) );
 		}

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
@@ -11,10 +11,12 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenEntity_Serialized_DoesNotIncludeOptionalParametersIfNull() {
+		public void SirenEntity_Serialized_DoesNotIncludeOptionalParametersIfNull(
+			[Values] bool useToJson
+		) {
 			ISirenEntity sirenEntity = new SirenEntity();
 
-			string serialized = JsonConvert.SerializeObject( sirenEntity );
+			string serialized = useToJson ? sirenEntity.ToJson() : JsonConvert.SerializeObject( sirenEntity );
 
 			ISirenEntity entity = JsonConvert.DeserializeObject<SirenEntity>( serialized );
 
@@ -30,10 +32,17 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenEntity_DeserializesCorrectly() {
+		public void SirenEntity_DeserializesCorrectly(
+			[Values] bool useToJson
+		) {
 			ISirenEntity sirenEntity = new SirenEntity(
 					properties: new {
-						foo = "bar"
+						foo = "bar",
+						baz = new {
+							baz1 = "cats",
+							baz2 = 2,
+							baz3 = true
+						}
 					},
 					links: new[] {
 						new SirenLink( rel: new[] { "self" }, href: new Uri( "http://example.com" ), @class: new[] { "class" } )
@@ -51,10 +60,13 @@ namespace D2L.Hypermedia.Siren.Tests {
 					type: "text/html"
 				);
 
-			string serialized = JsonConvert.SerializeObject( sirenEntity );
+			string serialized = useToJson ? sirenEntity.ToJson() : JsonConvert.SerializeObject( sirenEntity );
 			ISirenEntity entity = JsonConvert.DeserializeObject<SirenEntity>( serialized );
 
 			Assert.AreEqual( "bar", (string)entity.Properties.foo );
+			Assert.AreEqual( "cats", (string)entity.Properties.baz.baz1 );
+			Assert.AreEqual( 2, (int)entity.Properties.baz.baz2 );
+			Assert.AreEqual( true, (bool)entity.Properties.baz.baz3 );
 			Assert.AreEqual( 1, entity.Links.ToList().Count );
 			Assert.Contains( "organization", entity.Rel );
 			Assert.Contains( "some-class", entity.Class );
@@ -66,7 +78,9 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenEntity_Serialize_ExcludesRelClassEntitiesLinksAndActionsIfEmpty() {
+		public void SirenEntity_Serialize_ExcludesRelClassEntitiesLinksAndActionsIfEmpty(
+			[Values] bool useToJson
+		) {
 			ISirenEntity entity = new SirenEntity(
 					@class: new[] { "foo" },
 					rel: new[] { "bar" },
@@ -80,7 +94,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 						new SirenAction( name: "action-name", href: new Uri( "http://example.com" ), @class: new[] { "class" } )
 					}
 				);
-			string serialized = JsonConvert.SerializeObject( entity );
+			string serialized = useToJson ? entity.ToJson() : JsonConvert.SerializeObject( entity );
 			Assert.GreaterOrEqual( serialized.IndexOf( "rel", StringComparison.Ordinal ), -1 );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), -1 );
 			Assert.GreaterOrEqual( serialized.IndexOf( "entities", StringComparison.Ordinal ), -1 );
@@ -88,7 +102,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.GreaterOrEqual( serialized.IndexOf( "actions", StringComparison.Ordinal ), -1 );
 
 			entity = new SirenEntity();
-			serialized = JsonConvert.SerializeObject( entity );
+			serialized = useToJson ? entity.ToJson() : JsonConvert.SerializeObject( entity );
 			Assert.AreEqual( -1, serialized.IndexOf( "rel", StringComparison.Ordinal ) );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 			Assert.AreEqual( -1, serialized.IndexOf( "entities", StringComparison.Ordinal ) );

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
@@ -10,10 +10,12 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenField_Serialized_DoesNotIncludeOptionalParametersIfNull() {
+		public void SirenField_Serialized_DoesNotIncludeOptionalParametersIfNull(
+			[Values] bool useToJson
+		) {
 			ISirenField sirenField = new SirenField( name: "foo" );
 
-			string serialized = JsonConvert.SerializeObject( sirenField );
+			string serialized = useToJson ? sirenField.ToJson() : JsonConvert.SerializeObject( sirenField );
 			ISirenField field = JsonConvert.DeserializeObject<SirenField>( serialized );
 
 			Assert.AreEqual( "foo", field.Name );
@@ -24,10 +26,12 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenField_DeserializesCorrectly() {
+		public void SirenField_DeserializesCorrectly(
+			[Values] bool useToJson
+		) {
 			ISirenField sirenField = TestHelpers.GetField();
 
-			string serialized = JsonConvert.SerializeObject( sirenField );
+			string serialized = useToJson ? sirenField.ToJson() : JsonConvert.SerializeObject( sirenField );
 			ISirenField field = JsonConvert.DeserializeObject<SirenField>( serialized );
 
 			Assert.AreEqual( "foo", field.Name );
@@ -38,16 +42,18 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenField_Serialize_ExcludesClassIfEmpty() {
+		public void SirenField_Serialize_ExcludesClassIfEmpty(
+			[Values] bool useToJson
+		) {
 			ISirenField field = new SirenField(
 				name: "foo",
 				@class: new [] { "bar" }
 			);
-			string serialized = JsonConvert.SerializeObject( field );
+			string serialized = useToJson ? field.ToJson() : JsonConvert.SerializeObject( field );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
 
 			field = new SirenField( name: "foo" );
-			serialized = JsonConvert.SerializeObject( field );
+			serialized = useToJson ? field.ToJson() : JsonConvert.SerializeObject( field );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 		}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
@@ -10,13 +10,15 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenLink_Serialized_DoesNotIncludeOptionalParametersIfNull() {
+		public void SirenLink_Serialized_DoesNotIncludeOptionalParametersIfNull(
+			[Values] bool useToJson
+		) {
 			ISirenLink sirenLink = new SirenLink(
 				rel: new[] { "foo" },
 				href: new Uri( "http://example.com" )
 			);
 
-			string serialized = JsonConvert.SerializeObject( sirenLink );
+			string serialized = useToJson ? sirenLink.ToJson() : JsonConvert.SerializeObject( sirenLink );
 
 			ISirenLink link = JsonConvert.DeserializeObject<SirenLink>( serialized );
 
@@ -28,10 +30,12 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenLink_DeserializesCorrectly() {
+		public void SirenLink_DeserializesCorrectly(
+			[Values] bool useToJson
+		) {
 			ISirenLink sirenLink = TestHelpers.GetLink();
 
-			string serialized = JsonConvert.SerializeObject( sirenLink );
+			string serialized = useToJson ? sirenLink.ToJson() : JsonConvert.SerializeObject( sirenLink );
 
 			ISirenLink link = JsonConvert.DeserializeObject<SirenLink>( serialized );
 
@@ -43,20 +47,22 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenLink_Serialize_ExcludesClassIfEmptyArray() {
+		public void SirenLink_Serialize_ExcludesClassIfEmptyArray(
+			[Values] bool useToJson
+		) {
 			ISirenLink link = new SirenLink(
 				rel: new [] { "foo" },
 				href: new Uri( "http://example.com" ),
 				@class: new [] { "bar" }
 			);
-			string serialized = JsonConvert.SerializeObject( link );
+			string serialized = useToJson ? link.ToJson() : JsonConvert.SerializeObject( link );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
 
 			link = new SirenLink(
 				rel: new [] { "foo" },
 				href: new Uri( "http://example.com" )
 			);
-			serialized = JsonConvert.SerializeObject( link );
+			serialized = useToJson ? link.ToJson() : JsonConvert.SerializeObject( link );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 		}
 

--- a/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
+++ b/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
@@ -48,6 +48,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ISirenSerializable.cs" />
+    <Compile Include="JsonUtilities.cs" />
     <Compile Include="SirenMatchers.cs" />
     <Compile Include="SirenActionExtensions.cs" />
     <Compile Include="SirenEntityExtensions.cs" />

--- a/D2L.Hypermedia.Siren/ISirenAction.cs
+++ b/D2L.Hypermedia.Siren/ISirenAction.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace D2L.Hypermedia.Siren {
 
-	public interface ISirenAction : IEquatable<ISirenAction>, IComparable<ISirenAction>, IComparable {
+	public interface ISirenAction : ISirenSerializable, IEquatable<ISirenAction>, IComparable<ISirenAction>, IComparable {
 
 		string Name { get; }
 

--- a/D2L.Hypermedia.Siren/ISirenEntity.cs
+++ b/D2L.Hypermedia.Siren/ISirenEntity.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace D2L.Hypermedia.Siren {
 
-	public interface ISirenEntity : IEquatable<ISirenEntity>, IComparable<ISirenEntity>, IComparable {
+	public interface ISirenEntity : ISirenSerializable, IEquatable<ISirenEntity>, IComparable<ISirenEntity>, IComparable {
 
 		string[] Class { get; }
 

--- a/D2L.Hypermedia.Siren/ISirenField.cs
+++ b/D2L.Hypermedia.Siren/ISirenField.cs
@@ -2,7 +2,7 @@
 
 namespace D2L.Hypermedia.Siren {
 
-	public interface ISirenField : IEquatable<ISirenField>, IComparable<ISirenField>, IComparable {
+	public interface ISirenField : ISirenSerializable, IEquatable<ISirenField>, IComparable<ISirenField>, IComparable {
 
 		string Name { get; }
 

--- a/D2L.Hypermedia.Siren/ISirenLink.cs
+++ b/D2L.Hypermedia.Siren/ISirenLink.cs
@@ -2,7 +2,7 @@
 
 namespace D2L.Hypermedia.Siren {
 
-	public interface ISirenLink : IEquatable<ISirenLink>, IComparable<ISirenLink>, IComparable {
+	public interface ISirenLink : ISirenSerializable, IEquatable<ISirenLink>, IComparable<ISirenLink>, IComparable {
 
 		string[] Rel { get; }
 

--- a/D2L.Hypermedia.Siren/ISirenSerializable.cs
+++ b/D2L.Hypermedia.Siren/ISirenSerializable.cs
@@ -1,8 +1,12 @@
-﻿namespace D2L.Hypermedia.Siren {
+﻿using Newtonsoft.Json;
+
+namespace D2L.Hypermedia.Siren {
 
 	public interface ISirenSerializable {
 
 		string ToJson();
+
+		void ToJson( JsonWriter writer );
 
 	}
 

--- a/D2L.Hypermedia.Siren/ISirenSerializable.cs
+++ b/D2L.Hypermedia.Siren/ISirenSerializable.cs
@@ -1,0 +1,9 @@
+﻿namespace D2L.Hypermedia.Siren {
+
+	public interface ISirenSerializable {
+
+		string ToJson();
+
+	}
+
+}

--- a/D2L.Hypermedia.Siren/JsonUtilities.cs
+++ b/D2L.Hypermedia.Siren/JsonUtilities.cs
@@ -22,7 +22,7 @@ namespace D2L.Hypermedia.Siren {
 			writer.WriteEndArray();
 		}
 
-		public static void WriteJsonSerializable( JsonWriter writer, string propertyName, IEnumerable<ISirenSerializable> values ) {
+		public static void WriteJsonSerializables( JsonWriter writer, string propertyName, IEnumerable<ISirenSerializable> values ) {
 			if( values == null || !values.Any() ) {
 				return;
 			}
@@ -31,7 +31,7 @@ namespace D2L.Hypermedia.Siren {
 			writer.WriteStartArray();
 
 			foreach( ISirenSerializable serializable in values ) {
-				writer.WriteRawValue( serializable.ToJson() );
+				serializable.ToJson( writer );
 			}
 
 			writer.WriteEndArray();

--- a/D2L.Hypermedia.Siren/JsonUtilities.cs
+++ b/D2L.Hypermedia.Siren/JsonUtilities.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace D2L.Hypermedia.Siren {
+
+	public static class JsonUtilities {
+
+		public static void WriteJsonArray( JsonWriter writer, string propertyName, string[] values ) {
+			if( values == null || values.Length == 0 ) {
+				return;
+			}
+
+			writer.WritePropertyName( propertyName );
+			writer.WriteStartArray();
+
+			foreach( string value in values ) {
+				writer.WriteValue( value );
+			}
+
+			writer.WriteEndArray();
+		}
+
+		public static void WriteJsonSerializable( JsonWriter writer, string propertyName, IEnumerable<ISirenSerializable> values ) {
+			if( values == null || !values.Any() ) {
+				return;
+			}
+
+			writer.WritePropertyName( propertyName );
+			writer.WriteStartArray();
+
+			foreach( ISirenSerializable serializable in values ) {
+				writer.WriteRawValue( serializable.ToJson() );
+			}
+
+			writer.WriteEndArray();
+		}
+
+		public static void WriteJsonString( JsonWriter writer, string propertyName, string value ) {
+			if( value == null ) {
+				return;
+			}
+
+			writer.WritePropertyName( propertyName );
+			writer.WriteValue( value );
+		}
+
+		public static void WriteJsonUri( JsonWriter writer, string propertyName, Uri value ) {
+			if( value == null ) {
+				return;
+			}
+
+			writer.WritePropertyName( propertyName );
+			writer.WriteValue( value.AbsoluteUri );
+		}
+
+		public static void WriteJsonObject( JsonWriter writer, string propertyName, object value ) {
+			if( value == null ) {
+				return;
+			}
+
+			writer.WritePropertyName( propertyName );
+			writer.WriteValue( JsonConvert.SerializeObject( value ) );
+		}
+
+	}
+
+}

--- a/D2L.Hypermedia.Siren/JsonUtilities.cs
+++ b/D2L.Hypermedia.Siren/JsonUtilities.cs
@@ -61,7 +61,7 @@ namespace D2L.Hypermedia.Siren {
 			}
 
 			writer.WritePropertyName( propertyName );
-			writer.WriteValue( JsonConvert.SerializeObject( value ) );
+			writer.WriteRawValue( JsonConvert.SerializeObject( value ) );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -123,7 +125,23 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		string ISirenSerializable.ToJson() {
-			throw new NotImplementedException();
+			StringBuilder sb = new StringBuilder();
+			StringWriter sw = new StringWriter( sb );
+			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
+				writer.WriteStartObject();
+
+				JsonUtilities.WriteJsonArray( writer, "class", m_class );
+				JsonUtilities.WriteJsonString( writer, "type", m_type );
+				JsonUtilities.WriteJsonString( writer, "title", m_title );
+				JsonUtilities.WriteJsonUri( writer, "href", m_href );
+				JsonUtilities.WriteJsonString( writer, "name", m_name );
+				JsonUtilities.WriteJsonString( writer, "method", m_method );
+				JsonUtilities.WriteJsonSerializable( writer, "fields", m_fields );
+
+				writer.WriteEndObject();
+			}
+
+			return sb.ToString();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -128,20 +128,25 @@ namespace D2L.Hypermedia.Siren {
 			StringBuilder sb = new StringBuilder();
 			StringWriter sw = new StringWriter( sb );
 			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				writer.WriteStartObject();
-
-				JsonUtilities.WriteJsonArray( writer, "class", m_class );
-				JsonUtilities.WriteJsonString( writer, "type", m_type );
-				JsonUtilities.WriteJsonString( writer, "title", m_title );
-				JsonUtilities.WriteJsonUri( writer, "href", m_href );
-				JsonUtilities.WriteJsonString( writer, "name", m_name );
-				JsonUtilities.WriteJsonString( writer, "method", m_method );
-				JsonUtilities.WriteJsonSerializable( writer, "fields", m_fields );
-
-				writer.WriteEndObject();
+				ISirenSerializable @this = this;
+				@this.ToJson( writer );
 			}
 
 			return sb.ToString();
+		}
+
+		void ISirenSerializable.ToJson( JsonWriter writer ) {
+			writer.WriteStartObject();
+
+			JsonUtilities.WriteJsonArray( writer, "class", m_class );
+			JsonUtilities.WriteJsonString( writer, "type", m_type );
+			JsonUtilities.WriteJsonString( writer, "title", m_title );
+			JsonUtilities.WriteJsonUri( writer, "href", m_href );
+			JsonUtilities.WriteJsonString( writer, "name", m_name );
+			JsonUtilities.WriteJsonString( writer, "method", m_method );
+			JsonUtilities.WriteJsonSerializables( writer, "fields", m_fields );
+
+			writer.WriteEndObject();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -122,6 +122,10 @@ namespace D2L.Hypermedia.Siren {
 				^ m_fields.Select( x => x.GetHashCode() ).GetHashCode();
 		}
 
+		string ISirenSerializable.ToJson() {
+			throw new NotImplementedException();
+		}
+
 	}
 
 	public class HypermediaActionConverter : JsonConverter {

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -159,7 +161,25 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		string ISirenSerializable.ToJson() {
-			throw new NotImplementedException();
+			StringBuilder sb = new StringBuilder();
+			StringWriter sw = new StringWriter( sb );
+			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
+				writer.WriteStartObject();
+
+				JsonUtilities.WriteJsonArray( writer, "class", m_class );
+				JsonUtilities.WriteJsonArray( writer, "rel", m_rel );
+				JsonUtilities.WriteJsonString( writer, "type", m_type );
+				JsonUtilities.WriteJsonString( writer, "title", m_title );
+				JsonUtilities.WriteJsonUri( writer, "href", m_href );
+				JsonUtilities.WriteJsonObject( writer, "properties", m_properties );
+				JsonUtilities.WriteJsonSerializable( writer, "entities", m_entities );
+				JsonUtilities.WriteJsonSerializable( writer, "actions", m_actions );
+				JsonUtilities.WriteJsonSerializable( writer, "links", m_links );
+
+				writer.WriteEndObject();
+			}
+
+			return sb.ToString();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -158,6 +158,10 @@ namespace D2L.Hypermedia.Siren {
 
 		}
 
+		string ISirenSerializable.ToJson() {
+			throw new NotImplementedException();
+		}
+
 	}
 
 	public class HypermediaEntityConverter : JsonConverter {

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -164,22 +164,27 @@ namespace D2L.Hypermedia.Siren {
 			StringBuilder sb = new StringBuilder();
 			StringWriter sw = new StringWriter( sb );
 			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				writer.WriteStartObject();
-
-				JsonUtilities.WriteJsonArray( writer, "class", m_class );
-				JsonUtilities.WriteJsonArray( writer, "rel", m_rel );
-				JsonUtilities.WriteJsonString( writer, "type", m_type );
-				JsonUtilities.WriteJsonString( writer, "title", m_title );
-				JsonUtilities.WriteJsonUri( writer, "href", m_href );
-				JsonUtilities.WriteJsonObject( writer, "properties", m_properties );
-				JsonUtilities.WriteJsonSerializable( writer, "entities", m_entities );
-				JsonUtilities.WriteJsonSerializable( writer, "actions", m_actions );
-				JsonUtilities.WriteJsonSerializable( writer, "links", m_links );
-
-				writer.WriteEndObject();
+				ISirenSerializable @this = this;
+				@this.ToJson( writer );
 			}
 
 			return sb.ToString();
+		}
+
+		void ISirenSerializable.ToJson( JsonWriter writer ) {
+			writer.WriteStartObject();
+
+			JsonUtilities.WriteJsonArray( writer, "class", m_class );
+			JsonUtilities.WriteJsonArray( writer, "rel", m_rel );
+			JsonUtilities.WriteJsonString( writer, "type", m_type );
+			JsonUtilities.WriteJsonString( writer, "title", m_title );
+			JsonUtilities.WriteJsonUri( writer, "href", m_href );
+			JsonUtilities.WriteJsonObject( writer, "properties", m_properties );
+			JsonUtilities.WriteJsonSerializables( writer, "entities", m_entities );
+			JsonUtilities.WriteJsonSerializables( writer, "actions", m_actions );
+			JsonUtilities.WriteJsonSerializables( writer, "links", m_links );
+
+			writer.WriteEndObject();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -96,6 +96,10 @@ namespace D2L.Hypermedia.Siren {
 				^ m_title?.GetHashCode() ?? 0;
 		}
 
+		string ISirenSerializable.ToJson() {
+			throw new NotImplementedException();
+		}
+
 	}
 
 	public class HypermediaFieldConverter : JsonConverter {

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -97,7 +99,21 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		string ISirenSerializable.ToJson() {
-			throw new NotImplementedException();
+			StringBuilder sb = new StringBuilder();
+			StringWriter sw = new StringWriter( sb );
+			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
+				writer.WriteStartObject();
+
+				JsonUtilities.WriteJsonArray( writer, "class", m_class );
+				JsonUtilities.WriteJsonString( writer, "type", m_type );
+				JsonUtilities.WriteJsonString( writer, "title", m_title );
+				JsonUtilities.WriteJsonString( writer, "name", m_name );
+				JsonUtilities.WriteJsonObject( writer, "value", m_value );
+
+				writer.WriteEndObject();
+			}
+
+			return sb.ToString();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -102,18 +102,23 @@ namespace D2L.Hypermedia.Siren {
 			StringBuilder sb = new StringBuilder();
 			StringWriter sw = new StringWriter( sb );
 			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				writer.WriteStartObject();
-
-				JsonUtilities.WriteJsonArray( writer, "class", m_class );
-				JsonUtilities.WriteJsonString( writer, "type", m_type );
-				JsonUtilities.WriteJsonString( writer, "title", m_title );
-				JsonUtilities.WriteJsonString( writer, "name", m_name );
-				JsonUtilities.WriteJsonObject( writer, "value", m_value );
-
-				writer.WriteEndObject();
+				ISirenSerializable @this = this;
+				@this.ToJson( writer );
 			}
 
 			return sb.ToString();
+		}
+
+		void ISirenSerializable.ToJson( JsonWriter writer ) {
+			writer.WriteStartObject();
+
+			JsonUtilities.WriteJsonArray( writer, "class", m_class );
+			JsonUtilities.WriteJsonString( writer, "type", m_type );
+			JsonUtilities.WriteJsonString( writer, "title", m_title );
+			JsonUtilities.WriteJsonString( writer, "name", m_name );
+			JsonUtilities.WriteJsonObject( writer, "value", m_value );
+
+			writer.WriteEndObject();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -104,18 +104,23 @@ namespace D2L.Hypermedia.Siren {
 			StringBuilder sb = new StringBuilder();
 			StringWriter sw = new StringWriter( sb );
 			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				writer.WriteStartObject();
-
-				JsonUtilities.WriteJsonArray( writer, "class", m_class );
-				JsonUtilities.WriteJsonArray( writer, "rel", m_rel );
-				JsonUtilities.WriteJsonString( writer, "type", m_type );
-				JsonUtilities.WriteJsonString( writer, "title", m_title );
-				JsonUtilities.WriteJsonUri( writer, "href", m_href );
-
-				writer.WriteEndObject();
+				ISirenSerializable @this = this;
+				@this.ToJson( writer );
 			}
 
 			return sb.ToString();
+		}
+
+		void ISirenSerializable.ToJson( JsonWriter writer ) {
+			writer.WriteStartObject();
+
+			JsonUtilities.WriteJsonArray( writer, "class", m_class );
+			JsonUtilities.WriteJsonArray( writer, "rel", m_rel );
+			JsonUtilities.WriteJsonString( writer, "type", m_type );
+			JsonUtilities.WriteJsonString( writer, "title", m_title );
+			JsonUtilities.WriteJsonUri( writer, "href", m_href );
+
+			writer.WriteEndObject();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -99,7 +101,21 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		string ISirenSerializable.ToJson() {
-			throw new NotImplementedException();
+			StringBuilder sb = new StringBuilder();
+			StringWriter sw = new StringWriter( sb );
+			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
+				writer.WriteStartObject();
+
+				JsonUtilities.WriteJsonArray( writer, "class", m_class );
+				JsonUtilities.WriteJsonArray( writer, "rel", m_rel );
+				JsonUtilities.WriteJsonString( writer, "type", m_type );
+				JsonUtilities.WriteJsonString( writer, "title", m_title );
+				JsonUtilities.WriteJsonUri( writer, "href", m_href );
+
+				writer.WriteEndObject();
+			}
+
+			return sb.ToString();
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -98,6 +98,10 @@ namespace D2L.Hypermedia.Siren {
 				^ m_type?.GetHashCode() ?? 0;
 		}
 
+		string ISirenSerializable.ToJson() {
+			throw new NotImplementedException();
+		}
+
 	}
 
 	public class HypermediaLinkConverter : JsonConverter {

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ ISirenEntity entity = new SirenEntity(
 );
 ```
 
+Each `ISiren*` implements the `ISirenSerializable` interface, which includes the `ToJson` method. This is a custom JSON serializer, as it was found that using the default `JsonConvert.SerializeObject` could be very slow for large entities. The supporting attributes and functions for using `JsonConvert.SerializeObject` will be removed in a future release, meaning entities will no longer serialize correctly this way - `ToJson` will be the way to go.
+
 ### Extension methods and SirenMatchers
 
 There are numerous extension methods which allow you to extract a Siren representation from its parent, e.g. 


### PR DESCRIPTION
Some performance problems came up with using the built-in JsonConvert.SerializeObject due to hitting the (now-quite-expensive) .Equals method for entities. The recommended course of action here is to write our own serializer, which can be significantly faster. In our case, performance on a couple of not-previously-terrible routes improved by a significant margin (20-40%), and one route went from 30+ seconds to <1 second for a response. It's likely the latter case had something else going on too, but hey, across the board performance boosts are nice!