### PR TITLE
Improved JsonConverters

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -11,15 +11,13 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenAction_Serialized_DoesNotIncludeOptionalParametersIfNull(
-			[Values] bool useToJson
-		) {
+		public void SirenAction_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenAction sirenAction = new SirenAction(
 				name: "foo",
 				href: new Uri( "http://example.com" )
 			);
 
-			string serialized = useToJson ? sirenAction.ToJson() : JsonConvert.SerializeObject( sirenAction );
+			string serialized = JsonConvert.SerializeObject( sirenAction );
 			ISirenAction action = JsonConvert.DeserializeObject<SirenAction>( serialized );
 
 			Assert.AreEqual( "foo", action.Name );
@@ -32,9 +30,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenAction_DeserializesCorrectly(
-			[Values] bool useToJson
-		) {
+		public void SirenAction_DeserializesCorrectly() {
 			ISirenAction sirenAction = new SirenAction(
 				name: "foo",
 				href: new Uri( "http://example.com" ),
@@ -47,7 +43,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 				}
 			);
 
-			string serialized = useToJson ? sirenAction.ToJson() : JsonConvert.SerializeObject( sirenAction );
+			string serialized = JsonConvert.SerializeObject( sirenAction );
 			ISirenAction action = JsonConvert.DeserializeObject<SirenAction>( serialized );
 
 			Assert.AreEqual( "foo", action.Name );
@@ -60,16 +56,14 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenAction_Serialize_ExcludesClassAndFieldsIfEmpty(
-			[Values] bool useToJson
-		) {
+		public void SirenAction_Serialize_ExcludesClassAndFieldsIfEmpty() {
 			ISirenAction action = new SirenAction(
 				name: "foo",
 				href: new Uri( "http://example.com" ),
 				@class: new [] { "bar" },
 				fields: new [] { new SirenField( "baz" ) }
 			);
-			string serialized = useToJson ? action.ToJson() : JsonConvert.SerializeObject( action );
+			string serialized = JsonConvert.SerializeObject( action );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
 			Assert.GreaterOrEqual( serialized.IndexOf( "fields", StringComparison.Ordinal ), 0 );
 
@@ -77,7 +71,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 				name: "foo",
 				href: new Uri( "http://example.com" )
 			);
-			serialized = useToJson ? action.ToJson() : JsonConvert.SerializeObject( action );
+			serialized = JsonConvert.SerializeObject( action );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 			Assert.AreEqual( -1, serialized.IndexOf( "fields", StringComparison.Ordinal ) );
 		}

--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -8,8 +8,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 	[TestFixture]
 	public class SirenActionTests {
 
-		private string m_matchMessage;
-
 		[Test]
 		public void SirenAction_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenAction sirenAction = new SirenAction(

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
@@ -8,8 +8,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 	[TestFixture]
 	public class SirenEntityTests {
 
-		private string m_matchMessage;
-
 		[Test]
 		public void SirenEntity_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenEntity sirenEntity = new SirenEntity();

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
@@ -11,12 +11,10 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenEntity_Serialized_DoesNotIncludeOptionalParametersIfNull(
-			[Values] bool useToJson
-		) {
+		public void SirenEntity_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenEntity sirenEntity = new SirenEntity();
 
-			string serialized = useToJson ? sirenEntity.ToJson() : JsonConvert.SerializeObject( sirenEntity );
+			string serialized = JsonConvert.SerializeObject( sirenEntity );
 
 			ISirenEntity entity = JsonConvert.DeserializeObject<SirenEntity>( serialized );
 
@@ -32,9 +30,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenEntity_DeserializesCorrectly(
-			[Values] bool useToJson
-		) {
+		public void SirenEntity_DeserializesCorrectly() {
 			ISirenEntity sirenEntity = new SirenEntity(
 					properties: new {
 						foo = "bar",
@@ -60,7 +56,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 					type: "text/html"
 				);
 
-			string serialized = useToJson ? sirenEntity.ToJson() : JsonConvert.SerializeObject( sirenEntity );
+			string serialized = JsonConvert.SerializeObject( sirenEntity );
 			ISirenEntity entity = JsonConvert.DeserializeObject<SirenEntity>( serialized );
 
 			Assert.AreEqual( "bar", (string)entity.Properties.foo );
@@ -78,9 +74,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenEntity_Serialize_ExcludesRelClassEntitiesLinksAndActionsIfEmpty(
-			[Values] bool useToJson
-		) {
+		public void SirenEntity_Serialize_ExcludesRelClassEntitiesLinksAndActionsIfEmpty() {
 			ISirenEntity entity = new SirenEntity(
 					@class: new[] { "foo" },
 					rel: new[] { "bar" },
@@ -94,7 +88,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 						new SirenAction( name: "action-name", href: new Uri( "http://example.com" ), @class: new[] { "class" } )
 					}
 				);
-			string serialized = useToJson ? entity.ToJson() : JsonConvert.SerializeObject( entity );
+			string serialized = JsonConvert.SerializeObject( entity );
 			Assert.GreaterOrEqual( serialized.IndexOf( "rel", StringComparison.Ordinal ), -1 );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), -1 );
 			Assert.GreaterOrEqual( serialized.IndexOf( "entities", StringComparison.Ordinal ), -1 );
@@ -102,7 +96,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.GreaterOrEqual( serialized.IndexOf( "actions", StringComparison.Ordinal ), -1 );
 
 			entity = new SirenEntity();
-			serialized = useToJson ? entity.ToJson() : JsonConvert.SerializeObject( entity );
+			serialized = JsonConvert.SerializeObject( entity );
 			Assert.AreEqual( -1, serialized.IndexOf( "rel", StringComparison.Ordinal ) );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 			Assert.AreEqual( -1, serialized.IndexOf( "entities", StringComparison.Ordinal ) );

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
@@ -10,12 +10,10 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenField_Serialized_DoesNotIncludeOptionalParametersIfNull(
-			[Values] bool useToJson
-		) {
+		public void SirenField_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenField sirenField = new SirenField( name: "foo" );
 
-			string serialized = useToJson ? sirenField.ToJson() : JsonConvert.SerializeObject( sirenField );
+			string serialized = JsonConvert.SerializeObject( sirenField );
 			ISirenField field = JsonConvert.DeserializeObject<SirenField>( serialized );
 
 			Assert.AreEqual( "foo", field.Name );
@@ -26,12 +24,10 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenField_DeserializesCorrectly(
-			[Values] bool useToJson
-		) {
+		public void SirenField_DeserializesCorrectly() {
 			ISirenField sirenField = TestHelpers.GetField();
 
-			string serialized = useToJson ? sirenField.ToJson() : JsonConvert.SerializeObject( sirenField );
+			string serialized = JsonConvert.SerializeObject( sirenField );
 			ISirenField field = JsonConvert.DeserializeObject<SirenField>( serialized );
 
 			Assert.AreEqual( "foo", field.Name );
@@ -42,18 +38,16 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenField_Serialize_ExcludesClassIfEmpty(
-			[Values] bool useToJson
-		) {
+		public void SirenField_Serialize_ExcludesClassIfEmpty() {
 			ISirenField field = new SirenField(
 				name: "foo",
 				@class: new [] { "bar" }
 			);
-			string serialized = useToJson ? field.ToJson() : JsonConvert.SerializeObject( field );
+			string serialized = JsonConvert.SerializeObject( field );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
 
 			field = new SirenField( name: "foo" );
-			serialized = useToJson ? field.ToJson() : JsonConvert.SerializeObject( field );
+			serialized = JsonConvert.SerializeObject( field );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 		}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
@@ -7,8 +7,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 	[TestFixture]
 	public class SirenFieldTests {
 
-		private string m_matchMessage;
-
 		[Test]
 		public void SirenField_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenField sirenField = new SirenField( name: "foo" );

--- a/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
@@ -10,15 +10,13 @@ namespace D2L.Hypermedia.Siren.Tests {
 		private string m_matchMessage;
 
 		[Test]
-		public void SirenLink_Serialized_DoesNotIncludeOptionalParametersIfNull(
-			[Values] bool useToJson
-		) {
+		public void SirenLink_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenLink sirenLink = new SirenLink(
 				rel: new[] { "foo" },
 				href: new Uri( "http://example.com" )
 			);
 
-			string serialized = useToJson ? sirenLink.ToJson() : JsonConvert.SerializeObject( sirenLink );
+			string serialized = JsonConvert.SerializeObject( sirenLink );
 
 			ISirenLink link = JsonConvert.DeserializeObject<SirenLink>( serialized );
 
@@ -30,12 +28,10 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenLink_DeserializesCorrectly(
-			[Values] bool useToJson
-		) {
+		public void SirenLink_DeserializesCorrectly() {
 			ISirenLink sirenLink = TestHelpers.GetLink();
 
-			string serialized = useToJson ? sirenLink.ToJson() : JsonConvert.SerializeObject( sirenLink );
+			string serialized = JsonConvert.SerializeObject( sirenLink );
 
 			ISirenLink link = JsonConvert.DeserializeObject<SirenLink>( serialized );
 
@@ -47,22 +43,20 @@ namespace D2L.Hypermedia.Siren.Tests {
 		}
 
 		[Test]
-		public void SirenLink_Serialize_ExcludesClassIfEmptyArray(
-			[Values] bool useToJson
-		) {
+		public void SirenLink_Serialize_ExcludesClassIfEmptyArray() {
 			ISirenLink link = new SirenLink(
 				rel: new [] { "foo" },
 				href: new Uri( "http://example.com" ),
 				@class: new [] { "bar" }
 			);
-			string serialized = useToJson ? link.ToJson() : JsonConvert.SerializeObject( link );
+			string serialized = JsonConvert.SerializeObject( link );
 			Assert.GreaterOrEqual( serialized.IndexOf( "class", StringComparison.Ordinal ), 0 );
 
 			link = new SirenLink(
 				rel: new [] { "foo" },
 				href: new Uri( "http://example.com" )
 			);
-			serialized = useToJson ? link.ToJson() : JsonConvert.SerializeObject( link );
+			serialized = JsonConvert.SerializeObject( link );
 			Assert.AreEqual( -1, serialized.IndexOf( "class", StringComparison.Ordinal ) );
 		}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
@@ -7,8 +7,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 	[TestFixture]
 	public class SirenLinkTests {
 
-		private string m_matchMessage;
-
 		[Test]
 		public void SirenLink_Serialized_DoesNotIncludeOptionalParametersIfNull() {
 			ISirenLink sirenLink = new SirenLink(

--- a/D2L.Hypermedia.Siren/ISirenSerializable.cs
+++ b/D2L.Hypermedia.Siren/ISirenSerializable.cs
@@ -4,8 +4,6 @@ namespace D2L.Hypermedia.Siren {
 
 	public interface ISirenSerializable {
 
-		string ToJson();
-
 		void ToJson( JsonWriter writer );
 
 	}

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -108,17 +106,6 @@ namespace D2L.Hypermedia.Siren {
 				^ m_title?.GetHashCode() ?? 0
 				^ m_type?.GetHashCode() ?? 0
 				^ m_fields.Select( x => x.GetHashCode() ).GetHashCode();
-		}
-
-		string ISirenSerializable.ToJson() {
-			StringBuilder sb = new StringBuilder();
-			StringWriter sw = new StringWriter( sb );
-			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				ISirenSerializable @this = this;
-				@this.ToJson( writer );
-			}
-
-			return sb.ToString();
 		}
 
 		void ISirenSerializable.ToJson( JsonWriter writer ) {

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -127,10 +127,11 @@ namespace D2L.Hypermedia.Siren {
 	public class HypermediaActionEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			if( !( value is IEnumerable<ISirenAction> actions ) ) {
+			if( !( value is IEnumerable<ISirenAction> ) ) {
 				return;
 			}
 
+			IEnumerable<ISirenAction> actions = (IEnumerable<ISirenAction>)value;
 			writer.WriteStartArray();
 			foreach( ISirenAction action in actions ) {
 				action.ToJson( writer );

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -54,7 +54,7 @@ namespace D2L.Hypermedia.Siren {
 		public string Type => m_type;
 
 		[JsonProperty( "fields", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof(HypermediaFieldConverter) )]
+		[JsonConverter( typeof(HypermediaFieldEnumerableConverter) )]
 		public IEnumerable<ISirenField> Fields => m_fields;
 
 		public bool ShouldSerializeClass() {
@@ -137,10 +137,18 @@ namespace D2L.Hypermedia.Siren {
 
 	}
 
-	public class HypermediaActionConverter : JsonConverter {
+	public class HypermediaActionEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			serializer.Serialize( writer, value );
+			if( !( value is IEnumerable<ISirenAction> actions ) ) {
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach( ISirenAction action in actions ) {
+				action.ToJson( writer );
+			}
+			writer.WriteEndArray();
 		}
 
 		public override object ReadJson( JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer ) {
@@ -148,7 +156,7 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		public override bool CanConvert( Type objectType ) {
-			return objectType == typeof( SirenAction );
+			return typeof( IEnumerable<ISirenAction> ).IsAssignableFrom( objectType );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -48,15 +48,15 @@ namespace D2L.Hypermedia.Siren {
 		public dynamic Properties => m_properties;
 
 		[JsonProperty( "entities", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof(HypermediaEntityConverter) )]
+		[JsonConverter( typeof(HypermediaEntityEnumerableConverter) )]
 		public IEnumerable<ISirenEntity> Entities => m_entities;
 
 		[JsonProperty( "links", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof(HypermediaLinkConverter) )]
+		[JsonConverter( typeof(HypermediaLinkEnumerableConverter) )]
 		public IEnumerable<ISirenLink> Links => m_links;
 
 		[JsonProperty( "actions", NullValueHandling = NullValueHandling.Ignore )]
-		[JsonConverter( typeof(HypermediaActionConverter) )]
+		[JsonConverter( typeof(HypermediaActionEnumerableConverter) )]
 		public IEnumerable<ISirenAction> Actions => m_actions;
 
 		[JsonProperty( "title", NullValueHandling = NullValueHandling.Ignore )]
@@ -171,11 +171,18 @@ namespace D2L.Hypermedia.Siren {
 
 	}
 
-	public class HypermediaEntityConverter : JsonConverter {
-
+	public class HypermediaEntityEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			serializer.Serialize( writer, value );
+			if( !( value is IEnumerable<ISirenEntity> entities ) ) {
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach( ISirenEntity entity in entities ) {
+				entity.ToJson( writer );
+			}
+			writer.WriteEndArray();
 		}
 
 		public override object ReadJson( JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer ) {
@@ -183,7 +190,7 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		public override bool CanConvert( Type objectType ) {
-			return objectType == typeof( SirenEntity );
+			return typeof( IEnumerable<ISirenEntity> ).IsAssignableFrom( objectType );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -161,10 +161,11 @@ namespace D2L.Hypermedia.Siren {
 	public class HypermediaEntityEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			if( !( value is IEnumerable<ISirenEntity> entities ) ) {
+			if( !( value is IEnumerable<ISirenEntity> ) ) {
 				return;
 			}
 
+			IEnumerable<ISirenEntity> entities = (IEnumerable<ISirenEntity>)value;
 			writer.WriteStartArray();
 			foreach( ISirenEntity entity in entities ) {
 				entity.ToJson( writer );

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -140,17 +138,6 @@ namespace D2L.Hypermedia.Siren {
 				^ m_href?.GetHashCode() ?? 0
 				^ m_type?.GetHashCode() ?? 0;
 
-		}
-
-		string ISirenSerializable.ToJson() {
-			StringBuilder sb = new StringBuilder();
-			StringWriter sw = new StringWriter( sb );
-			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				ISirenSerializable @this = this;
-				@this.ToJson( writer );
-			}
-
-			return sb.ToString();
 		}
 
 		void ISirenSerializable.ToJson( JsonWriter writer ) {

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -87,17 +85,6 @@ namespace D2L.Hypermedia.Siren {
 				^ m_type?.GetHashCode() ?? 0
 				^ m_value?.ToString().GetHashCode() ?? 0
 				^ m_title?.GetHashCode() ?? 0;
-		}
-
-		string ISirenSerializable.ToJson() {
-			StringBuilder sb = new StringBuilder();
-			StringWriter sw = new StringWriter( sb );
-			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				ISirenSerializable @this = this;
-				@this.ToJson( writer );
-			}
-
-			return sb.ToString();
 		}
 
 		void ISirenSerializable.ToJson( JsonWriter writer ) {

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -104,10 +104,11 @@ namespace D2L.Hypermedia.Siren {
 	public class HypermediaFieldEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			if( !( value is IEnumerable<ISirenField> fields ) ) {
+			if( !( value is IEnumerable<ISirenField> ) ) {
 				return;
 			}
 
+			IEnumerable<ISirenField> fields = (IEnumerable<ISirenField>)value;
 			writer.WriteStartArray();
 			foreach( ISirenField field in fields ) {
 				field.ToJson( writer );

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -113,10 +114,18 @@ namespace D2L.Hypermedia.Siren {
 
 	}
 
-	public class HypermediaFieldConverter : JsonConverter {
+	public class HypermediaFieldEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			serializer.Serialize( writer, value );
+			if( !( value is IEnumerable<ISirenField> fields ) ) {
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach( ISirenField field in fields ) {
+				field.ToJson( writer );
+			}
+			writer.WriteEndArray();
 		}
 
 		public override object ReadJson( JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer ) {
@@ -124,7 +133,7 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		public override bool CanConvert( Type objectType ) {
-			return objectType == typeof( SirenField );
+			return typeof( IEnumerable<ISirenField> ).IsAssignableFrom( objectType );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace D2L.Hypermedia.Siren {
@@ -89,17 +87,6 @@ namespace D2L.Hypermedia.Siren {
 				^ string.Join( ",", m_class ).GetHashCode()
 				^ m_title?.GetHashCode() ?? 0
 				^ m_type?.GetHashCode() ?? 0;
-		}
-
-		string ISirenSerializable.ToJson() {
-			StringBuilder sb = new StringBuilder();
-			StringWriter sw = new StringWriter( sb );
-			using( JsonWriter writer = new JsonTextWriter( sw ) ) {
-				ISirenSerializable @this = this;
-				@this.ToJson( writer );
-			}
-
-			return sb.ToString();
 		}
 
 		void ISirenSerializable.ToJson( JsonWriter writer ) {

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -115,10 +116,18 @@ namespace D2L.Hypermedia.Siren {
 
 	}
 
-	public class HypermediaLinkConverter : JsonConverter {
+	public class HypermediaLinkEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			serializer.Serialize( writer, value );
+			if( !( value is IEnumerable<ISirenLink> links ) ) {
+				return;
+			}
+
+			writer.WriteStartArray();
+			foreach( ISirenLink link in links ) {
+				link.ToJson( writer );
+			}
+			writer.WriteEndArray();
 		}
 
 		public override object ReadJson( JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer ) {
@@ -126,7 +135,7 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		public override bool CanConvert( Type objectType ) {
-			return objectType == typeof( SirenLink );
+			return typeof( IEnumerable<ISirenLink> ).IsAssignableFrom( objectType );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -106,10 +106,11 @@ namespace D2L.Hypermedia.Siren {
 	public class HypermediaLinkEnumerableConverter : JsonConverter {
 
 		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer ) {
-			if( !( value is IEnumerable<ISirenLink> links ) ) {
+			if( !( value is IEnumerable<ISirenLink> ) ) {
 				return;
 			}
 
+			IEnumerable<ISirenLink> links = (IEnumerable<ISirenLink>)value;
 			writer.WriteStartArray();
 			foreach( ISirenLink link in links ) {
 				link.ToJson( writer );

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ ISirenEntity entity = new SirenEntity(
 );
 ```
 
-Each `ISiren*` implements the `ISirenSerializable` interface, which includes the `ToJson` method. This is a custom JSON serializer, as it was found that using the default `JsonConvert.SerializeObject` could be very slow for large entities. The supporting attributes and functions for using `JsonConvert.SerializeObject` will be removed in a future release, meaning entities will no longer serialize correctly this way - `ToJson` will be the way to go.
-
 ### Extension methods and SirenMatchers
 
 There are numerous extension methods which allow you to extract a Siren representation from its parent, e.g. 


### PR DESCRIPTION
Through a follow-up discussion about #14, @CodeBaboon came up with the idea of continuing to use `JsonConvert.SerializeObject( ISiren* )`, but still leveraging the faster custom serialization logic. Turns out, it's possible, and it's basically just as fast as using `ToJson` directly! This means we don't need to modify how we're serializing things, meaning anything already using the JsonConvert method will get the performance improvement without any change, 🙌 

This meant removing the `string ISirenSerializable.ToJson()`, since it's not used anywhere anymore.

This will be what's released to fix DE28217, as it will require only a version bump in the LMS, and no change to how we're serializing things.