### PR TITLE
Update appveyor

### DIFF
--- a/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
+++ b/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.1.0")]
-[assembly: AssemblyFileVersion("1.4.1.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/README.md
+++ b/README.md
@@ -70,14 +70,8 @@ This will verify that `actualEntity` at least contains what was specified in `ex
 
 ## Releasing
 
-1. Merge pull request to master - Appveyor will run on the merge
+1. Merge pull request to master
 
-2. Go to the Deployments tab in Appveyor
+2. Create release in GitHub, with a semver name of the format "v1.2.3"
 
-3. Click New Deployment
-
-4. Select the NuGet environment
-
-5. Click Deploy on the build you want to deploy (probably the most recent one)
-
-6. Verify that the package deployed successfully
+3. Appveyor will run on the new tag, and upload the new version to NuGet automatically

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,29 @@
-pull_requests:
-  do_not_increment_build_number: true
-skip_tags: true
 clone_depth: 5
+version: 1.0.0.{build}
+init:
+- ps: >-
+    if ($env:APPVEYOR_REPO_TAG -eq "true") {
+      Update-AppveyorBuild -Version "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))"
+    }
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
 nuget:
   account_feed: true
   project_feed: true
 before_build:
-  - nuget restore D2L.Hypermedia.Siren\D2L.Hypermedia.Siren.sln
+- nuget restore D2L.Hypermedia.Siren\D2L.Hypermedia.Siren.sln
 build:
   publish_nuget: true
   publish_nuget_symbols: true
   parallel: true
   verbosity: minimal
-configuration:
-- Release
+deploy:
+- provider: NuGet
+  api_key:
+    secure: u0+jSIJDY1OFj8BJ+oIsnTu72R4DFb/YDkCLub+oGzjSmSM8DmFTKzoSi7nIHDnp
+  skip_symbols: true
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
- Use automatic AssemblyInfo patching
- Add automatic deployment to NuGet on GitHub tag/release, and use tag name as version

Mostly used appveyor/ci#691 as a source for this.

This will now generate the .nupkg artifacts on every build, with the `AssemblyInfo` automatically updated to be the version number on the build. That version number is either automatically generated (and fairly nonsensical) for normal PR/merge builds, or it'll be the tag name for tag builds. Tag builds will also automatically release to NuGet.