### PR TITLE
US97770 Validate field type

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/Properties/AssemblyInfo.cs
+++ b/D2L.Hypermedia.Siren.Tests/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Desire2Learn")]
 [assembly: AssemblyProduct("D2L.Hypermedia.Siren.Tests")]
-[assembly: AssemblyCopyright("Copyright © Desire2Learn 2016")]
+[assembly: AssemblyCopyright("Copyright © Desire2Learn 2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
+++ b/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="ISirenSerializable.cs" />
     <Compile Include="JsonUtilities.cs" />
+    <Compile Include="SirenFieldType.cs" />
     <Compile Include="SirenMatchers.cs" />
     <Compile Include="SirenActionExtensions.cs" />
     <Compile Include="SirenEntityExtensions.cs" />

--- a/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
+++ b/D2L.Hypermedia.Siren/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Desire2Learn")]
 [assembly: AssemblyProduct("D2L.Hypermedia.Siren")]
-[assembly: AssemblyCopyright("Copyright © Desire2Learn 2017")]
+[assembly: AssemblyCopyright("Copyright © Desire2Learn 2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/D2L.Hypermedia.Siren/SirenFieldType.cs
+++ b/D2L.Hypermedia.Siren/SirenFieldType.cs
@@ -1,0 +1,27 @@
+﻿namespace D2L.Hypermedia.Siren {
+
+	public class SirenFieldType {
+
+		public static string Hidden => "hidden";
+		public static string Text => "text";
+		public static string Search => "search";
+		public static string Tel => "tel";
+		public static string Url => "url";
+		public static string Email => "email";
+		public static string Password => "password";
+		public static string Datetime => "datetime";
+		public static string Date => "date";
+		public static string Month => "month";
+		public static string Week => "week";
+		public static string Time => "time";
+		public static string DatetimeLocal => "datetime-local";
+		public static string Number => "number";
+		public static string Range => "range";
+		public static string Color => "color";
+		public static string Checkbox => "checkbox";
+		public static string Radio => "radio";
+		public static string File => "file";
+
+	}
+
+}


### PR DESCRIPTION
Siren imposes limits on what a Siren field's `type` can be, but this was not being enforced by this library. As a first step, add SirenFieldType, which includes all the valid field types. This is a non-breaking change, which will be followed up by updating usages of this library to use SirenFieldType instead of a string, followed by a breaking change here to update the constructor to only allow for SirenFieldType.