### PR TITLE
Throw when given expected properties

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
+++ b/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>D2L.Hypermedia.Siren.Tests</RootNamespace>
     <AssemblyName>D2L.Hypermedia.Siren.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,11 +33,11 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\D2L.Hypermedia.Siren\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\D2L.Hypermedia.Siren\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\D2L.Hypermedia.Siren\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/D2L.Hypermedia.Siren.Tests/MatchersTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/MatchersTests.cs
@@ -40,7 +40,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			expected = new Uri( "http://foo.com" );
 			actual = new Uri( "http://example.com" );
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, $"Expected {expected}, but was {actual}" ) );
+			Assert.AreEqual( message, "Expected http://foo.com/, but was http://example.com/" );
 		}
 
 		[Test]
@@ -60,12 +60,12 @@ namespace D2L.Hypermedia.Siren.Tests {
 			expected = 1;
 			actual = "foo";
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, $"Expected {expected}, but was {actual}" ) );
+			Assert.AreEqual( message, "Expected 1, but was foo" );
 
 			expected = "foo";
 			actual = "bar";
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, $"Expected {expected}, but was {actual}" ) );
+			Assert.AreEqual( message, "Expected foo, but was bar" );
 
 			expected = "foo";
 			actual = "foo";
@@ -80,14 +80,14 @@ namespace D2L.Hypermedia.Siren.Tests {
 			IEnumerable<object> actual = new string[] { };
 			Assert.IsTrue( SirenMatchers.Matches( expected, actual, out message ) );
 
-			expected = new[] { "foo" };
-			actual = new[] { "foo" };
+			expected = new[] { "foo", "bar" };
+			actual = new[] { "foo", "bar" };
 			Assert.IsTrue( SirenMatchers.Matches( expected, actual, out message ) );
 
-			expected = new[] { "foo" };
-			actual = new[] { "bar" };
+			expected = new[] { "foo", "bar" };
+			actual = new[] { "baz" };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, $"Expected {expected}, but was {actual}" ) );
+			Assert.AreEqual( message, "Expected [foo,bar], but was [baz]" );
 		}
 
 		[Test]
@@ -146,7 +146,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			) };
 			actual = new[] { action };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, "Expected action-name-foobar, but was action-name" ), message );
+			Assert.AreEqual( message, "Expected action-name-foobar, but was action-name" );
 
 			expected = new[] { new SirenAction(
 				name: action.Name,
@@ -163,7 +163,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			) };
 			actual = new [] { action };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, "Expected 1, but was " ), message );
+			Assert.AreEqual( message, "Expected 1, but was " );
 		}
 
 		[Test]
@@ -188,7 +188,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 			expected = new[] { new SirenEntity(
 				rel: entity.Rel,
 				@class: entity.Class,
-				properties: entity.Properties,
 				entities: entity.Entities,
 				links: entity.Links,
 				actions: entity.Actions,
@@ -202,7 +201,6 @@ namespace D2L.Hypermedia.Siren.Tests {
 			expected = new[] { new SirenEntity(
 				rel: entity.Rel,
 				@class: entity.Class,
-				properties: entity.Properties,
 				entities: new [] {
 					entity.Entities.ElementAt( 0 ),
 					entity.Entities.ElementAt( 1 )
@@ -231,7 +229,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			) };
 			actual = new[] { entity };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, "Expected different-title, but was entity3" ), message );
+			Assert.AreEqual( message, "Expected different-title, but was entity3" );
 
 			expected = new[] { new SirenEntity(
 				links: new [] {
@@ -242,7 +240,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			) };
 			actual = new[] { entity };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, "Expected different-title, but was link3" ), message );
+			Assert.AreEqual( message, "Expected different-title, but was link3" );
 
 			expected = new[] { new SirenEntity(
 				actions: new [] {
@@ -253,7 +251,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			) };
 			actual = new[] { entity };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, "Expected different-name, but was action3" ), message );
+			Assert.AreEqual( message, "Expected different-name, but was action3" );
 		}
 
 		[Test]
@@ -299,7 +297,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			) };
 			actual = new[] { field };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, "Expected foo, but was 1" ) );
+			Assert.AreEqual( message, "Expected foo, but was 1" );
 		}
 
 		[Test]
@@ -354,7 +352,19 @@ namespace D2L.Hypermedia.Siren.Tests {
 			) };
 			actual = new[] { link };
 			Assert.IsFalse( SirenMatchers.Matches( expected, actual, out message ) );
-			Assert.IsTrue( Regex.IsMatch( message, "Expected .*, but was .*" ) );
+			Assert.AreEqual( message, "Expected [different-rel], but was [foo]" );
+		}
+
+		[Test]
+		public void MatchingHelpers_ThrowsWhenGivenProperties() {
+			ISirenEntity expected = new SirenEntity(
+				properties: new {
+					foo = "bar"
+				}
+			);
+			ISirenEntity actual = expected;
+
+			Assert.Throws<ArgumentException>( () => SirenMatchers.Matches( expected, actual, out string _ ) );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren.Tests/packages.config
+++ b/D2L.Hypermedia.Siren.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net452" />
-  <package id="NUnit" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit" version="3.6.1" targetFramework="net452" />
 </packages>

--- a/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
+++ b/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>D2L.Hypermedia.Siren</RootNamespace>
     <AssemblyName>D2L.Hypermedia.Siren</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,10 +33,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/D2L.Hypermedia.Siren/SirenMatchers.cs
+++ b/D2L.Hypermedia.Siren/SirenMatchers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace D2L.Hypermedia.Siren {
@@ -6,6 +7,7 @@ namespace D2L.Hypermedia.Siren {
 	public static class SirenMatchers {
 
 		private const string m_messageTemplate = "Expected {0}, but was {1}";
+		private const string m_arrayMessageTemplate = "Expected [{0}], but was [{1}]";
 
 		public static bool Matches( string expected, string actual, out string message ) {
 			if( expected == null || expected == actual || expected.Equals( actual ) ) {
@@ -38,6 +40,10 @@ namespace D2L.Hypermedia.Siren {
 		}
 
 		public static bool Matches( ISirenEntity expected, ISirenEntity actual, out string message ) {
+			if( expected.Properties != null ) {
+				throw new ArgumentException( "SirenMatchers cannot compare properties - remove them from the expected entity" );
+			}
+
 			return Matches( expected.Rel, actual.Rel, out message )
 				&& Matches( expected.Class, actual.Class, out message )
 				// Need to figure out a good way to match dynamics - considering moving away from dynamic for Properties
@@ -75,28 +81,28 @@ namespace D2L.Hypermedia.Siren {
 			string tempMessage = null;
 			bool matches = false;
 
-			if( typeof(T) == typeof(ISirenAction) ) {
-				matches = ((IEnumerable<ISirenAction>)expectedSet).All(
+			if( typeof( T ) == typeof( ISirenAction ) ) {
+				matches = ( (IEnumerable<ISirenAction>)expectedSet ).All(
 					expectedAction => actualSet.Any(
 						actualAction => Matches( expectedAction, (ISirenAction)actualAction, out tempMessage )
 					) );
-			} else if( typeof(T) == typeof(ISirenEntity) ) {
+			} else if( typeof( T ) == typeof( ISirenEntity ) ) {
 				matches = ( (IEnumerable<ISirenEntity>)expectedSet ).All(
-					expectedAction => actualSet.Any(
-						actualAction => Matches( expectedAction, (ISirenEntity)actualAction, out tempMessage )
+					expectedEntity => actualSet.Any(
+						actualEntity => Matches( expectedEntity, (ISirenEntity)actualEntity, out tempMessage )
 					) );
-			} else if( typeof(T) == typeof(ISirenField) ) {
+			} else if( typeof( T ) == typeof( ISirenField ) ) {
 				matches = ( (IEnumerable<ISirenField>)expectedSet ).All(
-					expectedAction => actualSet.Any(
-						actualAction => Matches( expectedAction, (ISirenField)actualAction, out tempMessage )
+					expectedField => actualSet.Any(
+						actualField => Matches( expectedField, (ISirenField)actualField, out tempMessage )
 					) );
-			} else if ( typeof(T) == typeof(ISirenLink) ) {
+			} else if( typeof( T ) == typeof( ISirenLink ) ) {
 				matches = ( (IEnumerable<ISirenLink>)expectedSet ).All(
-					expectedAction => actualSet.Any(
-						actualAction => Matches( expectedAction, (ISirenLink)actualAction, out tempMessage )
+					expectedLink => actualSet.Any(
+						actualLink => Matches( expectedLink, (ISirenLink)actualLink, out tempMessage )
 					) );
 			} else {
-				tempMessage = string.Format( m_messageTemplate, expectedSet, actualSet );
+				tempMessage = string.Format( m_arrayMessageTemplate, string.Join( ",", expectedSet ), string.Join( ",", actualSet ) );
 			}
 
 			if( matches ) {

--- a/README.md
+++ b/README.md
@@ -54,12 +54,11 @@ Assert.IsTrue( SirenMatchers.Matches( expectedEntity, actualEntity, out message 
 
 This will verify that `actualEntity` at least contains what was specified in `expectedEntity`. If a match is not found, `message` will identify where it differs.
 
-> **Note**: Currently, `SirenMatchers` will not properly check Siren Properties. This is because `ISirenEntity.Properties` is `dynamic`, which is difficult to test equality in a reliable on. A future version may change this, but until then, properties must be manually checked for equality.
+> **Note**: Currently, `SirenMatchers` will not properly check Siren Properties. This is because `ISirenEntity.Properties` is `dynamic`, which is difficult to test equality on in a reliable way. A future version may change this, but until then, properties must be manually checked for equality.
 
 ## Contributing
 
-1. **Fork** the repository. Committing directly against this repository is
-   highly discouraged.
+1. **Fork** the repository. Committing directly against this repository is highly discouraged.
 
 2. Make your modifications in a branch, updating and writing new tests.
 
@@ -67,8 +66,7 @@ This will verify that `actualEntity` at least contains what was specified in `ex
 
 4. `rebase` your changes against master. *Do not merge*.
 
-5. Submit a pull request to this repository. Wait for tests to run and someone
-   to chime in.
+5. Submit a pull request to this repository. Wait for tests to run and someone to chime in.
 
 ## Releasing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 clone_depth: 5
 version: 1.0.0.{build}
+image: Visual Studio 2017
 init:
 - ps: >-
     if ($env:APPVEYOR_REPO_TAG -eq "true") {


### PR DESCRIPTION
To explicitly call out that `SirenMatchers` cannot be used to compare properties, disallow it entirely - if the passed in expectation has properties, throw.

Also cleaned up some assertion messages, since they were formatting as the rather-unhelpful "Expected [System.String], but was [System.String]".