### PR TITLE
Add a SirenEntityBuilder to build SirenEntity objects

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
+++ b/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="MatchersTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SirenActionTests.cs" />
+    <Compile Include="SirenEntityBuilderTests.cs" />
     <Compile Include="SirenEntityTests.cs" />
     <Compile Include="SirenFieldTests.cs" />
     <Compile Include="SirenLinkTests.cs" />

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityBuilderTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityBuilderTests.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace D2L.Hypermedia.Siren.Tests {
+
+    [TestFixture]
+    public class SirenEntityBuilderTests {
+
+        private static readonly Uri TestHref = new Uri( "http://example.com" );
+
+        [Test]
+        public void SirenEntityBuilder_Build_NothingAdded_ExpectEmptyEntity() {
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            ISirenEntity entity = builder.Build();
+
+            Assert.IsEmpty( entity.Class );
+            Assert.IsNull( entity.Properties );
+            Assert.IsEmpty( entity.Entities );
+            Assert.IsEmpty( entity.Links );
+            Assert.IsEmpty( entity.Actions );
+            Assert.IsNull( entity.Title );
+            Assert.IsEmpty( entity.Rel );
+            Assert.IsNull( entity.Href );
+            Assert.IsNull( entity.Type );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_Build_WithParams_ExpectEntityWithParams() {
+            string expectedTitle = "test-title";
+            Uri expectedHref = TestHref;
+            string expectedType = "test-type";
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            ISirenEntity entity = builder.Build( expectedTitle, expectedHref, expectedType );
+
+            Assert.AreEqual( expectedTitle, entity.Title );
+            Assert.AreEqual( expectedHref, entity.Href );
+            Assert.AreEqual( expectedType, entity.Type );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddRel_Single_ExpectEntityWithRels() {
+            string expectedRel1 = "first-rel";
+            string expectedRel2 = "second-rel";
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddRel( expectedRel1 );
+            builder.AddRel( expectedRel2 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 2, entity.Rel.Length );
+            Assert.Contains( expectedRel1, entity.Rel );
+            Assert.Contains( expectedRel2, entity.Rel );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddRel_Bulk_ExpectEntityWithRels() {
+            string expectedRel1 = "first-bulk-rel";
+            string expectedRel2 = "second-bulk-rel";
+            string expectedRel3 = "third-bulk-rel";
+            string[] rels = new[] {
+                expectedRel1, expectedRel3
+            };
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddRel( rels );
+            builder.AddRel( expectedRel2 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 3, entity.Rel.Length );
+            Assert.Contains( expectedRel1, entity.Rel );
+            Assert.Contains( expectedRel2, entity.Rel );
+            Assert.Contains( expectedRel3, entity.Rel );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddAction_ExpectEntityWithActions() {
+            ISirenAction expectedAction1 = TestHelpers.GetAction( "action-1" );
+            ISirenAction expectedAction2 = TestHelpers.GetAction( "action-2" );
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddAction( expectedAction1 );
+            builder.AddAction( expectedAction2 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 2, entity.Actions.Count() );
+            CollectionAssert.Contains( entity.Actions, expectedAction1 );
+            CollectionAssert.Contains( entity.Actions, expectedAction2 );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddActions_ExpectEntityWithActions() {
+            ISirenAction expectedAction1 = TestHelpers.GetAction( "action-bulk-1" );
+            ISirenAction expectedAction2 = TestHelpers.GetAction( "action-bulk-2" );
+            ISirenAction expectedAction3 = TestHelpers.GetAction( "action-bulk-3" );
+            IEnumerable<ISirenAction> actions = new[] {
+                expectedAction2, expectedAction3
+            };
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddAction( expectedAction1 );
+            builder.AddActions( actions );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 3, entity.Actions.Count() );
+            CollectionAssert.Contains( entity.Actions, expectedAction1 );
+            CollectionAssert.Contains( entity.Actions, expectedAction2 );
+            CollectionAssert.Contains( entity.Actions, expectedAction3 );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddLink_ExpectEntityWithLinks() {
+            ISirenLink expectedLink1 = TestHelpers.GetLink( "link-1" );
+            ISirenLink expectedLink2 = TestHelpers.GetLink( "link-2" );
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddLink( expectedLink1 );
+            builder.AddLink( expectedLink2 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 2, entity.Links.Count() );
+            CollectionAssert.Contains( entity.Links, expectedLink1 );
+            CollectionAssert.Contains( entity.Links, expectedLink2 );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddLinks_ExpectEntityWithLinks() {
+            ISirenLink expectedLink1 = TestHelpers.GetLink( "link-bulk-1" );
+            ISirenLink expectedLink2 = TestHelpers.GetLink( "link-bulk-2" );
+            ISirenLink expectedLink3 = TestHelpers.GetLink( "link-bulk-3" );
+            IEnumerable<ISirenLink> links = new[] {
+                expectedLink1, expectedLink2
+            };
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddLinks( links );
+            builder.AddLink( expectedLink3 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 3, entity.Links.Count() );
+            CollectionAssert.Contains( entity.Links, expectedLink1 );
+            CollectionAssert.Contains( entity.Links, expectedLink2 );
+            CollectionAssert.Contains( entity.Links, expectedLink3 );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddEntity_ExpectEntityWithEntities() {
+            ISirenEntity expectedEntity1 = TestHelpers.GetEntity( "entity-1" );
+            ISirenEntity expectedEntity2 = TestHelpers.GetEntity( "entity-2" );
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddEntity( expectedEntity1 );
+            builder.AddEntity( expectedEntity2 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 2, entity.Entities.Count() );
+            CollectionAssert.Contains( entity.Entities, expectedEntity1 );
+            CollectionAssert.Contains( entity.Entities, expectedEntity2 );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddEntities_ExpectEntityWithEntities() {
+            ISirenEntity expectedEntity1 = TestHelpers.GetEntity( "entity-bulk-1" );
+            ISirenEntity expectedEntity2 = TestHelpers.GetEntity( "entity-bulk-2" );
+            ISirenEntity expectedEntity3 = TestHelpers.GetEntity( "entity-bulk-3" );
+            IEnumerable<ISirenEntity> entities = new[] {
+                expectedEntity1, expectedEntity2
+            };
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddEntities( entities );
+            builder.AddEntity( expectedEntity3 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 3, entity.Entities.Count() );
+            CollectionAssert.Contains( entity.Entities, expectedEntity1 );
+            CollectionAssert.Contains( entity.Entities, expectedEntity2 );
+            CollectionAssert.Contains( entity.Entities, expectedEntity3 );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddProperty_NullProperty_ExpectEntityWithNullProperty() {
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddProperty( "testNullProperty", null );
+            ISirenEntity entity = builder.Build();
+
+            Assert.IsNotNull( entity.Properties );
+            Assert.IsNull( entity.Properties.testNullProperty );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddProperty_NonNullProperties_ExpectEntityWithProperties() {
+
+            IList<string> value1 = new List<string>();
+            string value2 = "my-value-2";
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddProperty( "myProp1", value1 );
+            builder.AddProperty( "myProp2", value2 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.IsNotNull( entity.Properties );
+            Assert.AreEqual( value1, entity.Properties.myProp1 );
+            Assert.AreEqual( value2, entity.Properties.myProp2 );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddClass_Single_ExpectEntityWithClasses() {
+            string expectedClass1 = "first-class";
+            string expectedClass2 = "second-class";
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+
+            builder.AddClass( expectedClass1 );
+            builder.AddClass( expectedClass2 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 2, entity.Class.Length );
+            Assert.Contains( expectedClass1, entity.Class );
+            Assert.Contains( expectedClass2, entity.Class );
+        }
+
+        [Test]
+        public void SirenEntityBuilder_AddClass_Bulk_ExpectEntityWithClasses() {
+            string expectedClass1 = "first-bulk-class";
+            string expectedClass2 = "second-bulk-class";
+            string expectedClass3 = "third-bulk-class";
+            string[] classes = new[] {
+                expectedClass1, expectedClass2
+            };
+
+            SirenEntityBuilder builder = new SirenEntityBuilder();
+            builder.AddClass( classes );
+            builder.AddClass( expectedClass3 );
+            ISirenEntity entity = builder.Build();
+
+            Assert.AreEqual( 3, entity.Class.Length );
+            Assert.Contains( expectedClass1, entity.Class );
+            Assert.Contains( expectedClass2, entity.Class );
+            Assert.Contains( expectedClass3, entity.Class );
+        }
+
+    }
+}

--- a/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
+++ b/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="ISirenSerializable.cs" />
     <Compile Include="JsonUtilities.cs" />
+    <Compile Include="SirenEntityBuilder.cs" />
     <Compile Include="SirenFieldType.cs" />
     <Compile Include="SirenMatchers.cs" />
     <Compile Include="SirenActionExtensions.cs" />

--- a/D2L.Hypermedia.Siren/SirenEntityBuilder.cs
+++ b/D2L.Hypermedia.Siren/SirenEntityBuilder.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace D2L.Hypermedia.Siren {
+    public sealed class SirenEntityBuilder {
+
+        private List<string> m_rel;
+        private List<ISirenAction> m_actions;
+        private List<ISirenLink> m_links;
+        private List<ISirenEntity> m_entities;
+        private IDictionary<string, object> m_properties;
+        private List<string> m_class;
+
+        public SirenEntityBuilder AddRel( string rel ) {
+            if( m_rel == null ) {
+                m_rel = new List<string>();
+            }
+
+            m_rel.Add( rel );
+            return this;
+        }
+
+        public SirenEntityBuilder AddRel( IEnumerable<string> rels ) {
+            if( m_rel == null ) {
+                m_rel = new List<string>();
+            }
+
+            m_rel.AddRange( rels );
+            return this;
+        }
+
+
+        public SirenEntityBuilder AddAction( ISirenAction action ) {
+            if( m_actions == null ) {
+                m_actions = new List<ISirenAction>();
+            }
+
+            m_actions.Add( action );
+            return this;
+        }
+
+        public SirenEntityBuilder AddActions( IEnumerable<ISirenAction> actions ) {
+            if( m_actions == null ) {
+                m_actions = new List<ISirenAction>();
+            }
+
+            m_actions.AddRange( actions );
+            return this;
+        }
+
+
+        public SirenEntityBuilder AddLink( ISirenLink link ) {
+            if( m_links == null ) {
+                m_links = new List<ISirenLink>();
+            }
+
+            m_links.Add( link );
+            return this;
+        }
+
+
+        public SirenEntityBuilder AddLinks( IEnumerable<ISirenLink> links ) {
+            if( m_links == null ) {
+                m_links = new List<ISirenLink>();
+            }
+
+            m_links.AddRange( links );
+            return this;
+        }
+
+        public SirenEntityBuilder AddEntity( ISirenEntity entity ) {
+            if( m_entities == null ) {
+                m_entities = new List<ISirenEntity>();
+            }
+
+            m_entities.Add( entity );
+            return this;
+        }
+
+        public SirenEntityBuilder AddEntities( IEnumerable<ISirenEntity> entities ) {
+            if( m_entities == null ) {
+                m_entities = new List<ISirenEntity>();
+            }
+
+            m_entities.AddRange( entities );
+            return this;
+        }
+
+        public SirenEntityBuilder AddProperty( string name, object value ) {
+            if( m_properties == null ) {
+                m_properties = new ExpandoObject();
+            }
+
+            m_properties.Add( name, value );
+            return this;
+        }
+
+        public SirenEntityBuilder AddClass( string @class ) {
+            if( m_class == null ) {
+                m_class = new List<string>();
+            }
+
+            m_class.Add( @class );
+            return this;
+        }
+
+        public SirenEntityBuilder AddClass( IEnumerable<string> classes ) {
+            if( m_class == null ) {
+                m_class = new List<string>();
+            }
+
+            m_class.AddRange( classes );
+            return this;
+        }
+
+        public ISirenEntity Build(
+            string title = null,
+            Uri href = null,
+            string type = null
+        ) {
+            ISirenEntity entity = new SirenEntity(
+                rel: m_rel?.ToArray(),
+                @class: m_class?.ToArray(),
+                properties: m_properties,
+                entities: m_entities,
+                links: m_links,
+                actions: m_actions,
+                title: title,
+                href: href,
+                type: type
+            );
+            return entity;
+        }
+
+    }
+}


### PR DESCRIPTION
# Changes

- Add a `SirenEntityBuilder` to allow the following parameters to be progressively added to build up a `SirenEntity` in multiple steps before calling `Build` to create the final immutable `SirenEntity`
    - rels
    - actions
     - links
     - entities
     - properties
     - classes

# Motivation

To be able to pass around `SirenEntity`s in a mutable state while they are being built before creating their finalized immutable version.