### PR TITLE
Hashcode often equals 0

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
+++ b/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\D2L.Hypermedia.Siren\D2L.Hypermedia.Siren.csproj">
-      <Project>{11695B7A-07C5-4F65-A1E2-8BCC5A9690A6}</Project>
+      <Project>{11695b7a-07c5-4f65-a1e2-8bcc5a9690a6}</Project>
       <Name>D2L.Hypermedia.Siren</Name>
     </ProjectReference>
   </ItemGroup>

--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -176,8 +176,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			TestHelpers.ArrayBidirectionalEquality( actions, others, false );
 		}
 
-		private static ISirenAction[] HashCodeActions()
-        {
+		private static ISirenAction[] HashCodeActions() {
 			return new ISirenAction[]
             {
 				new SirenAction(

--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -236,35 +236,30 @@ namespace D2L.Hypermedia.Siren.Tests {
             };
         }
 
-		private static TestCaseData[] HashCodeTests()
-        {
-           return HashCodeActions().Select( x => new TestCaseData( x ) ).ToArray() ;
-        }
+		private static TestCaseData[] HashCodeTests() {
+			return HashCodeActions().Select( x => new TestCaseData( x ) ).ToArray();
+		}
 
 		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
-            foreach( var action1 in HashCodeActions() )
-            {
-                var innerEntities = HashCodeActions().ToList();
+			foreach( var action1 in HashCodeActions() ) {
+				var innerEntities = HashCodeActions().ToList();
 				innerEntities.Remove( action1 );
-                foreach (var action2 in innerEntities )
-                {
-                    yield return new TestCaseData( action1, action2 );
-                }
+				foreach( var action2 in innerEntities ) {
+					yield return new TestCaseData( action1, action2 );
+				}
 
-            }
-        }
+			}
+		}
 
-        [TestCaseSource( nameof( HashCodeTests ) ) ]
-		public void SirenAction_GetHashcodeNot0( ISirenAction action )
-        {
+		[TestCaseSource( nameof( HashCodeTests ) )]
+		public void SirenAction_GetHashcodeNot0( ISirenAction action ) {
 			Assert.AreNotEqual( 0, action.GetHashCode() );
-        }
+		}
 
-		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
-		public void SirenAction_GetHashCode_NotEqual( ISirenAction action1, ISirenAction action2 )
-        {
+		[TestCaseSource( nameof( HashCodeEqualityTests ) )]
+		public void SirenAction_GetHashCode_NotEqual( ISirenAction action1, ISirenAction action2 ) {
 			Assert.AreNotEqual( action1.GetHashCode(), action2.GetHashCode() );
-        }
+		}
 
 	}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenActionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -174,6 +175,96 @@ namespace D2L.Hypermedia.Siren.Tests {
 			others = new [] { TestHelpers.GetAction( "foo" ) };
 			TestHelpers.ArrayBidirectionalEquality( actions, others, false );
 		}
+
+		private static ISirenAction[] HashCodeActions()
+        {
+			return new ISirenAction[]
+            {
+				new SirenAction(
+					name: "action",
+					href: new Uri( "http://localhost" )
+					),
+				new SirenAction(
+					name: "action",
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "action" },
+					method: "POST",
+					title: "Create",
+					type: "application/x-www-form-urlencoded",
+					fields: new []{ TestHelpers.GetField() }
+					),
+				new SirenAction(
+					name: "action",
+					href: new Uri( "http://localhost" ),
+					method: "POST",
+					title: "Create",
+					type: "application/x-www-form-urlencoded",
+					fields: new []{ TestHelpers.GetField() }
+					),
+				new SirenAction(
+					name: "action",
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "action" },
+					title: "Create",
+					type: "application/x-www-form-urlencoded",
+					fields: new []{ TestHelpers.GetField() }
+					),
+				new SirenAction(
+					name: "action",
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "action" },
+					method: "POST",
+					type: "application/x-www-form-urlencoded",
+					fields: new []{ TestHelpers.GetField() }
+					),
+				new SirenAction(
+					name: "action",
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "action" },
+					method: "POST",
+					title: "Create",
+					fields: new []{ TestHelpers.GetField() }
+					),
+				new SirenAction(
+					name: "action",
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "action" },
+					method: "POST",
+					title: "Create",
+					type: "application/x-www-form-urlencoded"
+					),
+            };
+        }
+
+		private static TestCaseData[] HashCodeTests()
+        {
+           return HashCodeActions().Select( x => new TestCaseData( x ) ).ToArray() ;
+        }
+
+		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
+            foreach( var action1 in HashCodeActions() )
+            {
+                var innerEntities = HashCodeActions().ToList();
+				innerEntities.Remove( action1 );
+                foreach (var action2 in innerEntities )
+                {
+                    yield return new TestCaseData( action1, action2 );
+                }
+
+            }
+        }
+
+        [TestCaseSource( nameof( HashCodeTests ) ) ]
+		public void SirenAction_GetHashcodeNot0( ISirenAction action )
+        {
+			Assert.AreNotEqual( 0, action.GetHashCode() );
+        }
+
+		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
+		public void SirenAction_GetHashCode_NotEqual( ISirenAction action1, ISirenAction action2 )
+        {
+			Assert.AreNotEqual( action1.GetHashCode(), action2.GetHashCode() );
+        }
 
 	}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
@@ -216,10 +216,10 @@ namespace D2L.Hypermedia.Siren.Tests {
 			others = new [] { TestHelpers.GetEntity( "foo" ) };
 			TestHelpers.ArrayBidirectionalEquality( entities, others, false );
 		}
-				public static SirenEntity[] HashCodeEntities()
-        {
-			return new []
-            {
+
+		public static SirenEntity[] HashCodeEntities() {
+			return new[]
+			{
 				new SirenEntity(
 							rel: new [] { "rootrel" },
 							@class: new []{ "root" },
@@ -229,7 +229,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 							actions: new [] { TestHelpers.GetAction() },
 							title: "fooTitle",
 							href: new Uri("http://localhost"),
-							type: "fooType"		
+							type: "fooType"
 					),
 				new SirenEntity(
 							@class: new []{ "root" },
@@ -239,120 +239,115 @@ namespace D2L.Hypermedia.Siren.Tests {
 							actions: new [] { TestHelpers.GetAction() },
 							title: "fooTitle",
 							href: new Uri("http://localhost"),
-							type: "fooType"		
+							type: "fooType"
 					),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            properties: new { prop="value" },
-                            entities: new [] { TestHelpers.GetEntity() },
-                            links: new ISirenLink[] { TestHelpers.GetLink() },
-                            actions: new [] { TestHelpers.GetAction() },
-                            title: "fooTitle",
-                            href: new Uri("http://localhost"),
-                            type: "fooType"
-                    ),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            @class: new []{ "root" },
-                            entities: new [] { TestHelpers.GetEntity() },
-                            links: new ISirenLink[] { TestHelpers.GetLink() },
-                            actions: new [] { TestHelpers.GetAction() },
-                            title: "fooTitle",
-                            href: new Uri("http://localhost"),
-                            type: "fooType"
-                    ),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            @class: new []{ "root" },
-                            properties: new { prop="value" },
-                            links: new ISirenLink[] { TestHelpers.GetLink() },
-                            actions: new [] { TestHelpers.GetAction() },
-                            title: "fooTitle",
-                            href: new Uri("http://localhost"),
-                            type: "fooType"
-                    ),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            @class: new []{ "root" },
-                            properties: new { prop="value" },
-                            entities: new [] { TestHelpers.GetEntity() },
-                            actions: new [] { TestHelpers.GetAction() },
-                            title: "fooTitle",
-                            href: new Uri("http://localhost"),
-                            type: "fooType"
-                    ),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            @class: new []{ "root" },
-                            properties: new { prop="value" },
-                            entities: new [] { TestHelpers.GetEntity() },
-                            links: new ISirenLink[] { TestHelpers.GetLink() },
-                            title: "fooTitle",
-                            href: new Uri("http://localhost"),
-                            type: "fooType"
-                    ),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            @class: new []{ "root" },
-                            properties: new { prop="value" },
-                            entities: new [] { TestHelpers.GetEntity() },
-                            links: new ISirenLink[] { TestHelpers.GetLink() },
-                            actions: new [] { TestHelpers.GetAction() },
-                            href: new Uri("http://localhost"),
-                            type: "fooType"
-                    ),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            @class: new []{ "root" },
-                            properties: new { prop="value" },
-                            entities: new [] { TestHelpers.GetEntity() },
-                            links: new ISirenLink[] { TestHelpers.GetLink() },
-                            actions: new [] { TestHelpers.GetAction() },
-                            title: "fooTitle",
-                            type: "fooType"
-                    ),
-                new SirenEntity(
-                            rel: new [] { "rootrel" },
-                            @class: new []{ "root" },
-                            properties: new { prop="value" },
-                            entities: new [] { TestHelpers.GetEntity() },
-                            links: new ISirenLink[] { TestHelpers.GetLink() },
-                            actions: new [] { TestHelpers.GetAction() },
-                            title: "fooTitle",
-                            href: new Uri("http://localhost")
-                    ),
-            };
-        }
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							href: new Uri("http://localhost"),
+							type: "fooType"
+					),
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							href: new Uri("http://localhost"),
+							type: "fooType"
+					),
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							href: new Uri("http://localhost"),
+							type: "fooType"
+					),
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							href: new Uri("http://localhost"),
+							type: "fooType"
+					),
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							title: "fooTitle",
+							href: new Uri("http://localhost"),
+							type: "fooType"
+					),
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							href: new Uri("http://localhost"),
+							type: "fooType"
+					),
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							type: "fooType"
+					),
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							href: new Uri("http://localhost")
+					),
+			};
+		}
 
-        private static TestCaseData[] HashCodeTests()
-        {
-           return HashCodeEntities().Select( x => new TestCaseData( x ) ).ToArray() ;
-        }
+		private static TestCaseData[] HashCodeTests() {
+			return HashCodeEntities().Select( x => new TestCaseData( x ) ).ToArray();
+		}
 
 		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
-            foreach( var entity1 in HashCodeEntities() )
-            {
-                var innerEntities = HashCodeEntities().ToList();
+			foreach( var entity1 in HashCodeEntities() ) {
+				var innerEntities = HashCodeEntities().ToList();
 				innerEntities.Remove( entity1 );
-                foreach (var entity2 in innerEntities )
-                {
-                    yield return new TestCaseData( entity1, entity2 );
-                }
+				foreach( var entity2 in innerEntities ) {
+					yield return new TestCaseData( entity1, entity2 );
+				}
 
-            }
-        }
+			}
+		}
 
-        [TestCaseSource( nameof( HashCodeTests ) ) ]
-		public void SirenEntity_GetHashcodeNot0( ISirenEntity entity )
-        {
+		[TestCaseSource( nameof( HashCodeTests ) )]
+		public void SirenEntity_GetHashcodeNot0( ISirenEntity entity ) {
 			Assert.AreNotEqual( 0, entity.GetHashCode() );
-        }
+		}
 
-		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
-		public void SirenEntity_GetHashCode_NotEqual( ISirenEntity entity1, ISirenEntity entity2 )
-        {
+		[TestCaseSource( nameof( HashCodeEqualityTests ) )]
+		public void SirenEntity_GetHashCode_NotEqual( ISirenEntity entity1, ISirenEntity entity2 ) {
 			Assert.AreNotEqual( entity1.GetHashCode(), entity2.GetHashCode() );
-        }
+		}
 
 	}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenEntityTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -69,6 +70,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.AreEqual( "Entity title", entity.Title );
 			Assert.AreEqual( "http://example.com/3", entity.Href.ToString() );
 			Assert.AreEqual( "text/html", entity.Type );
+			Assert.AreNotEqual( 0, entity.GetHashCode() );
 		}
 
 		[Test]
@@ -214,6 +216,143 @@ namespace D2L.Hypermedia.Siren.Tests {
 			others = new [] { TestHelpers.GetEntity( "foo" ) };
 			TestHelpers.ArrayBidirectionalEquality( entities, others, false );
 		}
+				public static SirenEntity[] HashCodeEntities()
+        {
+			return new []
+            {
+				new SirenEntity(
+							rel: new [] { "rootrel" },
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							href: new Uri("http://localhost"),
+							type: "fooType"		
+					),
+				new SirenEntity(
+							@class: new []{ "root" },
+							properties: new { prop="value" },
+							entities: new [] { TestHelpers.GetEntity() },
+							links: new ISirenLink[] { TestHelpers.GetLink() },
+							actions: new [] { TestHelpers.GetAction() },
+							title: "fooTitle",
+							href: new Uri("http://localhost"),
+							type: "fooType"		
+					),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            properties: new { prop="value" },
+                            entities: new [] { TestHelpers.GetEntity() },
+                            links: new ISirenLink[] { TestHelpers.GetLink() },
+                            actions: new [] { TestHelpers.GetAction() },
+                            title: "fooTitle",
+                            href: new Uri("http://localhost"),
+                            type: "fooType"
+                    ),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            @class: new []{ "root" },
+                            entities: new [] { TestHelpers.GetEntity() },
+                            links: new ISirenLink[] { TestHelpers.GetLink() },
+                            actions: new [] { TestHelpers.GetAction() },
+                            title: "fooTitle",
+                            href: new Uri("http://localhost"),
+                            type: "fooType"
+                    ),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            @class: new []{ "root" },
+                            properties: new { prop="value" },
+                            links: new ISirenLink[] { TestHelpers.GetLink() },
+                            actions: new [] { TestHelpers.GetAction() },
+                            title: "fooTitle",
+                            href: new Uri("http://localhost"),
+                            type: "fooType"
+                    ),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            @class: new []{ "root" },
+                            properties: new { prop="value" },
+                            entities: new [] { TestHelpers.GetEntity() },
+                            actions: new [] { TestHelpers.GetAction() },
+                            title: "fooTitle",
+                            href: new Uri("http://localhost"),
+                            type: "fooType"
+                    ),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            @class: new []{ "root" },
+                            properties: new { prop="value" },
+                            entities: new [] { TestHelpers.GetEntity() },
+                            links: new ISirenLink[] { TestHelpers.GetLink() },
+                            title: "fooTitle",
+                            href: new Uri("http://localhost"),
+                            type: "fooType"
+                    ),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            @class: new []{ "root" },
+                            properties: new { prop="value" },
+                            entities: new [] { TestHelpers.GetEntity() },
+                            links: new ISirenLink[] { TestHelpers.GetLink() },
+                            actions: new [] { TestHelpers.GetAction() },
+                            href: new Uri("http://localhost"),
+                            type: "fooType"
+                    ),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            @class: new []{ "root" },
+                            properties: new { prop="value" },
+                            entities: new [] { TestHelpers.GetEntity() },
+                            links: new ISirenLink[] { TestHelpers.GetLink() },
+                            actions: new [] { TestHelpers.GetAction() },
+                            title: "fooTitle",
+                            type: "fooType"
+                    ),
+                new SirenEntity(
+                            rel: new [] { "rootrel" },
+                            @class: new []{ "root" },
+                            properties: new { prop="value" },
+                            entities: new [] { TestHelpers.GetEntity() },
+                            links: new ISirenLink[] { TestHelpers.GetLink() },
+                            actions: new [] { TestHelpers.GetAction() },
+                            title: "fooTitle",
+                            href: new Uri("http://localhost")
+                    ),
+            };
+        }
+
+        private static TestCaseData[] HashCodeTests()
+        {
+           return HashCodeEntities().Select( x => new TestCaseData( x ) ).ToArray() ;
+        }
+
+		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
+            foreach( var entity1 in HashCodeEntities() )
+            {
+                var innerEntities = HashCodeEntities().ToList();
+				innerEntities.Remove( entity1 );
+                foreach (var entity2 in innerEntities )
+                {
+                    yield return new TestCaseData( entity1, entity2 );
+                }
+
+            }
+        }
+
+        [TestCaseSource( nameof( HashCodeTests ) ) ]
+		public void SirenEntity_GetHashcodeNot0( ISirenEntity entity )
+        {
+			Assert.AreNotEqual( 0, entity.GetHashCode() );
+        }
+
+		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
+		public void SirenEntity_GetHashCode_NotEqual( ISirenEntity entity1, ISirenEntity entity2 )
+        {
+			Assert.AreNotEqual( entity1.GetHashCode(), entity2.GetHashCode() );
+        }
 
 	}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
@@ -98,6 +100,100 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.DoesNotThrow( () => new SirenField( "foo", type: "search" ) );
 			Assert.DoesNotThrow( () => new SirenField( "foo", type: SirenFieldType.Search ) );
 		}
+		
+		private static ISirenField[] HashCodeFields()
+        {
+			return new ISirenField[]
+            {
+				new SirenField(
+					name: "field",
+					@class: new[] { "fieldclass" },
+					type: SirenFieldType.Color,
+					value: "value",
+					title: "title",
+					min: decimal.MinValue,
+					max: decimal.MaxValue
+					),
+				new SirenField(
+					name: "field",
+					type: SirenFieldType.Color,
+					value: "value",
+					title: "title",
+					min: decimal.MinValue,
+					max: decimal.MaxValue
+					),
+				new SirenField(
+					name: "field",
+					@class: new[] { "fieldclass" },
+					value: "value",
+					title: "title",
+					min: decimal.MinValue,
+					max: decimal.MaxValue
+					),
+				new SirenField(
+					name: "field",
+					@class: new[] { "fieldclass" },
+					type: SirenFieldType.Color,
+					title: "title",
+					min: decimal.MinValue,
+					max: decimal.MaxValue
+					),
+				new SirenField(
+					name: "field",
+					@class: new[] { "fieldclass" },
+					type: SirenFieldType.Color,
+					value: "value",
+					min: decimal.MinValue,
+					max: decimal.MaxValue
+					),
+				new SirenField(
+					name: "field",
+					@class: new[] { "fieldclass" },
+					type: SirenFieldType.Color,
+					value: "value",
+					title: "title",
+					max: decimal.MaxValue
+					),
+				new SirenField(
+					name: "field",
+					@class: new[] { "fieldclass" },
+					type: SirenFieldType.Color,
+					value: "value",
+					title: "title",
+					min: decimal.MinValue
+					),
+            };
+        }
+
+		private static TestCaseData[] HashCodeTests()
+        {
+           return HashCodeFields().Select( x => new TestCaseData( x ) ).ToArray() ;
+        }
+
+		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
+            foreach( var field1 in HashCodeFields() )
+            {
+                var innerEntities = HashCodeFields().ToList();
+				innerEntities.Remove( field1 );
+                foreach (var field2 in innerEntities )
+                {
+                    yield return new TestCaseData( field1, field2 );
+                }
+
+            }
+        }
+
+        [TestCaseSource( nameof( HashCodeTests ) ) ]
+		public void SirenField_GetHashcodeNot0( ISirenField field )
+        {
+			Assert.AreNotEqual( 0, field.GetHashCode() );
+        }
+
+		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
+		public void SirenField_GetHashCode_NotEqual( ISirenField field1, ISirenField field2 )
+        {
+			Assert.AreNotEqual( field1.GetHashCode(), field2.GetHashCode() );
+        }
 
 	}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
@@ -100,11 +100,10 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.DoesNotThrow( () => new SirenField( "foo", type: "search" ) );
 			Assert.DoesNotThrow( () => new SirenField( "foo", type: SirenFieldType.Search ) );
 		}
-		
-		private static ISirenField[] HashCodeFields()
-        {
+
+		private static ISirenField[] HashCodeFields() {
 			return new ISirenField[]
-            {
+			{
 				new SirenField(
 					name: "field",
 					@class: new[] { "fieldclass" },
@@ -162,38 +161,33 @@ namespace D2L.Hypermedia.Siren.Tests {
 					title: "title",
 					min: decimal.MinValue
 					),
-            };
-        }
+			};
+		}
 
-		private static TestCaseData[] HashCodeTests()
-        {
-           return HashCodeFields().Select( x => new TestCaseData( x ) ).ToArray() ;
-        }
+		private static TestCaseData[] HashCodeTests() {
+			return HashCodeFields().Select( x => new TestCaseData( x ) ).ToArray();
+		}
 
 		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
-            foreach( var field1 in HashCodeFields() )
-            {
-                var innerEntities = HashCodeFields().ToList();
+			foreach( var field1 in HashCodeFields() ) {
+				var innerEntities = HashCodeFields().ToList();
 				innerEntities.Remove( field1 );
-                foreach (var field2 in innerEntities )
-                {
-                    yield return new TestCaseData( field1, field2 );
-                }
+				foreach( var field2 in innerEntities ) {
+					yield return new TestCaseData( field1, field2 );
+				}
 
-            }
-        }
+			}
+		}
 
-        [TestCaseSource( nameof( HashCodeTests ) ) ]
-		public void SirenField_GetHashcodeNot0( ISirenField field )
-        {
+		[TestCaseSource( nameof( HashCodeTests ) )]
+		public void SirenField_GetHashcodeNot0( ISirenField field ) {
 			Assert.AreNotEqual( 0, field.GetHashCode() );
-        }
+		}
 
-		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
-		public void SirenField_GetHashCode_NotEqual( ISirenField field1, ISirenField field2 )
-        {
+		[TestCaseSource( nameof( HashCodeEqualityTests ) )]
+		public void SirenField_GetHashCode_NotEqual( ISirenField field1, ISirenField field2 ) {
 			Assert.AreNotEqual( field1.GetHashCode(), field2.GetHashCode() );
-        }
+		}
 
 	}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
@@ -97,6 +99,68 @@ namespace D2L.Hypermedia.Siren.Tests {
 			others = new [] { TestHelpers.GetLink( "foo" ) };
 			TestHelpers.ArrayBidirectionalEquality( links, others, false );
 		}
+
+		private static ISirenLink[] HashCodeLinks()
+        {
+			return new[]
+            {
+				new SirenLink(
+					rel: new []{ "linkrel" },
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "linkclass" },
+					title: "title",
+					type: "type"
+					),
+				new SirenLink(
+					rel: new []{ "linkrel" },
+					href: new Uri( "http://localhost" ),
+					title: "title",
+					type: "type"
+					),
+				new SirenLink(
+					rel: new []{ "linkrel" },
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "linkclass" },
+					type: "type"
+					),
+				new SirenLink(
+					rel: new []{ "linkrel" },
+					href: new Uri( "http://localhost" ),
+					@class: new [] { "linkclass" },
+					title: "title"
+					)
+            };
+        }
+
+		private static TestCaseData[] HashCodeTests()
+        {
+           return HashCodeLinks().Select( x => new TestCaseData( x ) ).ToArray() ;
+        }
+
+		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
+            foreach( var link1 in HashCodeLinks() )
+            {
+                var innerEntities = HashCodeLinks().ToList();
+				innerEntities.Remove( link1 );
+                foreach (var link2 in innerEntities )
+                {
+                    yield return new TestCaseData( link1, link2 );
+                }
+
+            }
+        }
+
+        [TestCaseSource( nameof( HashCodeTests ) ) ]
+		public void SirenLink_GetHashcodeNot0( ISirenLink link )
+        {
+			Assert.AreNotEqual( 0, link.GetHashCode() );
+        }
+
+		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
+		public void SirenLink_GetHashCode_NotEqual( ISirenLink link1, ISirenLink link2 )
+        {
+			Assert.AreNotEqual( link1.GetHashCode(), link2.GetHashCode() );
+        }
 
 	}
 

--- a/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenLinkTests.cs
@@ -100,10 +100,9 @@ namespace D2L.Hypermedia.Siren.Tests {
 			TestHelpers.ArrayBidirectionalEquality( links, others, false );
 		}
 
-		private static ISirenLink[] HashCodeLinks()
-        {
+		private static ISirenLink[] HashCodeLinks() {
 			return new[]
-            {
+			{
 				new SirenLink(
 					rel: new []{ "linkrel" },
 					href: new Uri( "http://localhost" ),
@@ -129,38 +128,33 @@ namespace D2L.Hypermedia.Siren.Tests {
 					@class: new [] { "linkclass" },
 					title: "title"
 					)
-            };
-        }
+			};
+		}
 
-		private static TestCaseData[] HashCodeTests()
-        {
-           return HashCodeLinks().Select( x => new TestCaseData( x ) ).ToArray() ;
-        }
+		private static TestCaseData[] HashCodeTests() {
+			return HashCodeLinks().Select( x => new TestCaseData( x ) ).ToArray();
+		}
 
 		private static IEnumerable<TestCaseData> HashCodeEqualityTests() {
-            foreach( var link1 in HashCodeLinks() )
-            {
-                var innerEntities = HashCodeLinks().ToList();
+			foreach( var link1 in HashCodeLinks() ) {
+				var innerEntities = HashCodeLinks().ToList();
 				innerEntities.Remove( link1 );
-                foreach (var link2 in innerEntities )
-                {
-                    yield return new TestCaseData( link1, link2 );
-                }
+				foreach( var link2 in innerEntities ) {
+					yield return new TestCaseData( link1, link2 );
+				}
 
-            }
-        }
+			}
+		}
 
-        [TestCaseSource( nameof( HashCodeTests ) ) ]
-		public void SirenLink_GetHashcodeNot0( ISirenLink link )
-        {
+		[TestCaseSource( nameof( HashCodeTests ) )]
+		public void SirenLink_GetHashcodeNot0( ISirenLink link ) {
 			Assert.AreNotEqual( 0, link.GetHashCode() );
-        }
+		}
 
-		[TestCaseSource( nameof( HashCodeEqualityTests ) ) ]
-		public void SirenLink_GetHashCode_NotEqual( ISirenLink link1, ISirenLink link2 )
-        {
+		[TestCaseSource( nameof( HashCodeEqualityTests ) )]
+		public void SirenLink_GetHashCode_NotEqual( ISirenLink link1, ISirenLink link2 ) {
 			Assert.AreNotEqual( link1.GetHashCode(), link2.GetHashCode() );
-        }
+		}
 
 	}
 

--- a/D2L.Hypermedia.Siren/SirenAction.cs
+++ b/D2L.Hypermedia.Siren/SirenAction.cs
@@ -101,10 +101,10 @@ namespace D2L.Hypermedia.Siren {
 		public override int GetHashCode() {
 			return m_name.GetHashCode()
 				^ string.Join( ",", m_class ).GetHashCode()
-				^ m_method?.GetHashCode() ?? 0
-				^ m_href?.GetHashCode() ?? 0
-				^ m_title?.GetHashCode() ?? 0
-				^ m_type?.GetHashCode() ?? 0
+				^ ( m_method?.GetHashCode() ?? 0 )
+				^ ( m_href?.GetHashCode() ?? 0 )
+				^ ( m_title?.GetHashCode() ?? 0 )
+				^ ( m_type?.GetHashCode() ?? 0 )
 				^ m_fields.Select( x => x.GetHashCode() ).GetHashCode();
 		}
 

--- a/D2L.Hypermedia.Siren/SirenEntity.cs
+++ b/D2L.Hypermedia.Siren/SirenEntity.cs
@@ -130,13 +130,13 @@ namespace D2L.Hypermedia.Siren {
 		public override int GetHashCode() {
 			return string.Join( ",", m_rel ).GetHashCode()
 				^ string.Join( ",", m_class ).GetHashCode()
-				^ m_properties?.GetHashCode() ?? 0
+				^ ( m_properties?.GetHashCode() ?? 0 )
 				^ string.Join( ",", m_entities ).GetHashCode()
 				^ string.Join( ",", m_links ).GetHashCode()
 				^ string.Join( ",", m_actions ).GetHashCode()
-				^ m_title?.GetHashCode() ?? 0
-				^ m_href?.GetHashCode() ?? 0
-				^ m_type?.GetHashCode() ?? 0;
+				^ ( m_title?.GetHashCode() ?? 0 )
+				^ ( m_href?.GetHashCode() ?? 0 )
+				^ ( m_type?.GetHashCode() ?? 0 );
 
 		}
 

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -109,11 +109,11 @@ namespace D2L.Hypermedia.Siren {
 		public override int GetHashCode() {
 			return m_name.GetHashCode()
 				^ string.Join( ",", m_class ).GetHashCode()
-				^ m_type?.GetHashCode() ?? 0
-				^ m_value?.ToString().GetHashCode() ?? 0
-				^ m_title?.GetHashCode() ?? 0
-				^ m_min?.GetHashCode() ?? 0
-				^ m_max?.GetHashCode() ?? 0;
+				^ ( m_type?.GetHashCode() ?? 0 )
+				^ ( m_value?.ToString().GetHashCode() ?? 0 )
+				^ ( m_title?.GetHashCode() ?? 0 )
+				^ ( m_min?.GetHashCode() ?? 0 )
+				^ ( m_max?.GetHashCode() ?? 0 );
 		}
 
 		void ISirenSerializable.ToJson( JsonWriter writer ) {

--- a/D2L.Hypermedia.Siren/SirenLink.cs
+++ b/D2L.Hypermedia.Siren/SirenLink.cs
@@ -85,8 +85,8 @@ namespace D2L.Hypermedia.Siren {
 			return string.Join( ",", m_rel ).GetHashCode()
 				^ m_href.GetHashCode()
 				^ string.Join( ",", m_class ).GetHashCode()
-				^ m_title?.GetHashCode() ?? 0
-				^ m_type?.GetHashCode() ?? 0;
+				^ ( m_title?.GetHashCode() ?? 0 )
+				^ ( m_type?.GetHashCode() ?? 0 );
 		}
 
 		void ISirenSerializable.ToJson( JsonWriter writer ) {


### PR DESCRIPTION
I believe that the ?? operator is taking precedence for the bitwise operations (please correct me if i'm wrong!).  We're planning on using the hashcode and if it collides every time one of the nullable fields is null.... well that won't work very well :)

Ping @NolanKingdon @AlexBedley 