### PR TITLE
feat: Add SirenFieldValueObject from spec

### DIFF
--- a/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
+++ b/D2L.Hypermedia.Siren.Tests/D2L.Hypermedia.Siren.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="SirenActionTests.cs" />
     <Compile Include="SirenEntityBuilderTests.cs" />
     <Compile Include="SirenEntityTests.cs" />
+    <Compile Include="SirenFieldValueObjectTests.cs" />
     <Compile Include="SirenFieldTests.cs" />
     <Compile Include="SirenLinkTests.cs" />
     <Compile Include="TestHelpers.cs" />

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldTests.cs
@@ -99,6 +99,13 @@ namespace D2L.Hypermedia.Siren.Tests {
 			Assert.Throws<ArgumentException>( () => new SirenField( "foo", type: "invalid-type" ) );
 			Assert.DoesNotThrow( () => new SirenField( "foo", type: "search" ) );
 			Assert.DoesNotThrow( () => new SirenField( "foo", type: SirenFieldType.Search ) );
+
+			Assert.Throws<ArgumentException>( () => new SirenField( "foo", new[] { TestHelpers.GetFieldValueObject() }, type: "invalid-type" ) );
+			Assert.Throws<ArgumentException>( () => new SirenField( "foo", new[] { TestHelpers.GetFieldValueObject() }, type: SirenFieldType.Search ) );
+			Assert.DoesNotThrow( () => new SirenField( "foo", new[] { TestHelpers.GetFieldValueObject() }, type: "radio" ) );
+			Assert.DoesNotThrow( () => new SirenField( "foo", new[] { TestHelpers.GetFieldValueObject() }, type: SirenFieldType.Radio ) );
+			Assert.DoesNotThrow( () => new SirenField( "foo", new[] { TestHelpers.GetFieldValueObject() }, type: "checkbox" ) );
+			Assert.DoesNotThrow( () => new SirenField( "foo", new[] { TestHelpers.GetFieldValueObject() }, type: SirenFieldType.Checkbox ) );
 		}
 
 		private static ISirenField[] HashCodeFields() {
@@ -187,6 +194,18 @@ namespace D2L.Hypermedia.Siren.Tests {
 		[TestCaseSource( nameof( HashCodeEqualityTests ) )]
 		public void SirenField_GetHashCode_NotEqual( ISirenField field1, ISirenField field2 ) {
 			Assert.AreNotEqual( field1.GetHashCode(), field2.GetHashCode() );
+		}
+
+		[Test]
+		public void SirenField_BuildWithSirenFieldValueObject() {
+			SirenFieldValueObject[] sirenFieldValueObjects = new[] {
+				new SirenFieldValueObject( 1, "This is the first radio button", true ),
+				new SirenFieldValueObject( 2, "This is the second radio button", false )
+			};
+
+			SirenField sirenField = new SirenField( "radio buttons", sirenFieldValueObjects, SirenFieldType.Radio );
+
+			Assert.AreEqual( sirenFieldValueObjects, sirenField.Value );
 		}
 
 	}

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldValueObjectTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldValueObjectTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace D2L.Hypermedia.Siren.Tests {
+
+	[TestFixture]
+	public class SirenFieldValueObjectTests {
+
+		[Test]
+		public void SirenFieldValueObject_Serialized_DoesNotIncludeOptionalParametersIfNull() {
+			SirenFieldValueObject sirenFieldValueObject = TestHelpers.GetFieldValueObject();
+
+			string serialized = JsonConvert.SerializeObject( sirenFieldValueObject );
+			SirenFieldValueObject field = JsonConvert.DeserializeObject<SirenFieldValueObject>( serialized );
+
+			Assert.AreEqual( "foo", field.Value );
+			Assert.IsNull( field.Title );
+			Assert.AreEqual( false, field.Selected );
+		}
+
+		[Test]
+		public void SirenFieldValueObject_DeserializesCorrectly() {
+			SirenFieldValueObject sirenFieldValueObject = TestHelpers.GetFieldValueObject( 1 );
+
+			string serialized = JsonConvert.SerializeObject( sirenFieldValueObject );
+			SirenFieldValueObject field = JsonConvert.DeserializeObject<SirenFieldValueObject>( serialized );
+
+			Assert.AreEqual( 1, field.Value );
+			Assert.AreEqual( "Some field", field.Title );
+			Assert.AreEqual( false, field.Selected );
+		}
+
+		[Test]
+		public void SirenFieldValueObject_Equality_SameField_ShouldBeEqual() {
+			SirenFieldValueObject field = TestHelpers.GetFieldValueObject();
+			SirenFieldValueObject other = TestHelpers.GetFieldValueObject();
+			Assert.AreEqual(field, other);
+		}
+
+		[Test]
+		public void SirenFieldValueObject_Equality_MissingAttributes_ShouldNotBeEqual() {
+			SirenFieldValueObject field = TestHelpers.GetFieldValueObject();
+			SirenFieldValueObject other = new SirenFieldValueObject( "foo" );
+			Assert.AreNotEqual( field, other );
+		}
+
+		[Test]
+		public void SirenFieldValueObject_Equality_DifferentValue_ShouldNotBeEqual() {
+			SirenFieldValueObject field = TestHelpers.GetFieldValueObject();
+			SirenFieldValueObject other = TestHelpers.GetFieldValueObject( "bar" );
+			Assert.AreNotEqual( field, other );
+		}
+
+		[Test]
+		public void SirenFieldValueObject_ValidatesType() {
+			Assert.Throws<ArgumentNullException>( () => new SirenFieldValueObject( null ) );
+		}
+
+	}
+
+}

--- a/D2L.Hypermedia.Siren.Tests/SirenFieldValueObjectTests.cs
+++ b/D2L.Hypermedia.Siren.Tests/SirenFieldValueObjectTests.cs
@@ -11,7 +11,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 
 		[Test]
 		public void SirenFieldValueObject_Serialized_DoesNotIncludeOptionalParametersIfNull() {
-			SirenFieldValueObject sirenFieldValueObject = TestHelpers.GetFieldValueObject();
+			SirenFieldValueObject sirenFieldValueObject = new SirenFieldValueObject( "foo" );
 
 			string serialized = JsonConvert.SerializeObject( sirenFieldValueObject );
 			SirenFieldValueObject field = JsonConvert.DeserializeObject<SirenFieldValueObject>( serialized );
@@ -29,7 +29,7 @@ namespace D2L.Hypermedia.Siren.Tests {
 			SirenFieldValueObject field = JsonConvert.DeserializeObject<SirenFieldValueObject>( serialized );
 
 			Assert.AreEqual( 1, field.Value );
-			Assert.AreEqual( "Some field", field.Title );
+			Assert.AreEqual( "Some field option", field.Title );
 			Assert.AreEqual( false, field.Selected );
 		}
 

--- a/D2L.Hypermedia.Siren.Tests/TestHelpers.cs
+++ b/D2L.Hypermedia.Siren.Tests/TestHelpers.cs
@@ -85,6 +85,20 @@ namespace D2L.Hypermedia.Siren.Tests {
 			);
 		}
 
+		public static SirenFieldValueObject GetFieldValueObject( string value = "foo" ) {
+			return new SirenFieldValueObject(
+				value: value,
+				title: "Some field option"
+			);
+		}
+
+		public static SirenFieldValueObject GetFieldValueObject( int value ) {
+			return new SirenFieldValueObject(
+				value: value,
+				title: "Some field option"
+			);
+		}
+
 		public static ISirenLink GetLink( string rel = "foo" ) {
 			return new SirenLink(
 				rel: new[] { rel },

--- a/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
+++ b/D2L.Hypermedia.Siren/D2L.Hypermedia.Siren.csproj
@@ -51,6 +51,7 @@
     <Compile Include="JsonUtilities.cs" />
     <Compile Include="SirenEntityBuilder.cs" />
     <Compile Include="SirenFieldType.cs" />
+    <Compile Include="SirenFieldValueObject.cs" />
     <Compile Include="SirenMatchers.cs" />
     <Compile Include="SirenActionExtensions.cs" />
     <Compile Include="SirenEntityExtensions.cs" />

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -33,17 +33,37 @@ namespace D2L.Hypermedia.Siren {
 			m_max = max;
 		}
 
+		public SirenField(
+			string name,
+			IEnumerable<SirenFieldValueObject> values,
+			string type,
+			string[] @class = null,
+			string title = null
+		) {
+			if( type != SirenFieldType.Checkbox && type != SirenFieldType.Radio ) {
+				throw new ArgumentException( "Must be either checkbox or radio", nameof( type ) );
+			}
+
+			m_name = name;
+			m_class = @class ?? new string[0];
+			m_type = type;
+			m_value = values;
+			m_title = title;
+			m_min = null;
+			m_max = null;
+		}
+
 		private string ValidateType( string type ) {
 			if( type == null ) {
 				return null;
 			}
 
 			type = type.ToLowerInvariant();
-			if (SirenFieldType.ValidTypes.Contains( type ) ) {
+			if( SirenFieldType.ValidTypes.Contains( type ) ) {
 				return type;
 			}
 
-			throw new ArgumentException( $"\"{type}\" is not a valid type for a Siren Field. See the Siren documentation, or use SirenFieldTypes.");
+			throw new ArgumentException( $"\"{type}\" is not a valid type for a Siren Field. See the Siren documentation, or use SirenFieldTypes." );
 		}
 
 		[JsonProperty( "name" )]
@@ -79,7 +99,7 @@ namespace D2L.Hypermedia.Siren {
 			bool name = m_name == other.Name;
 			bool @class = m_class.OrderBy( x => x ).SequenceEqual( other.Class.OrderBy( x => x ) );
 			bool type = m_type == other.Type;
-			bool value = m_value == other.Value || m_value != null && m_value.Equals( other.Value );
+			bool value = m_value == other.Value || ( m_value != null && m_value.Equals( other.Value ) );
 			bool title = m_title == other.Title;
 			bool min = m_min == other.Min;
 			bool max = m_max == other.Max;

--- a/D2L.Hypermedia.Siren/SirenField.cs
+++ b/D2L.Hypermedia.Siren/SirenField.cs
@@ -15,6 +15,7 @@ namespace D2L.Hypermedia.Siren {
 		private readonly decimal? m_min;
 		private readonly decimal? m_max;
 
+		[JsonConstructor]
 		public SirenField(
 			string name,
 			string[] @class = null,

--- a/D2L.Hypermedia.Siren/SirenFieldValueObject.cs
+++ b/D2L.Hypermedia.Siren/SirenFieldValueObject.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace D2L.Hypermedia.Siren {
+
+	public record struct SirenFieldValueObject {
+
+		public SirenFieldValueObject( string value, string title = null, bool selected = false ) {
+			Value = value ?? throw new ArgumentNullException( nameof( value ) );
+			Title = title;
+			Selected = selected;
+		}
+
+		public SirenFieldValueObject( int value, string title = null, bool selected = false ) {
+			Value = value;
+			Title = title;
+			Selected = selected;
+		}
+
+		public SirenFieldValueObject( double value, string title = null, bool selected = false ) {
+			Value = value;
+			Title = title;
+			Selected = selected;
+		}
+
+		[JsonProperty( "title", NullValueHandling = NullValueHandling.Ignore )]
+		public string Title;
+
+		[JsonProperty( "value" )]
+		public object Value; // Can only be string or number, according to the spec
+
+		[JsonProperty( "selected" )]
+		public bool Selected = false;
+	}
+
+}


### PR DESCRIPTION
[US155092](https://rally1.rallydev.com/#/?detail=/userstory/708743294119&fdp=true): Update siren library for radio buttons

**Context**
Implement the `SirenFieldValueObject` as requested in https://github.com/Brightspace/D2L.Hypermedia.Siren/issues/39.

**Quality**
- [the spec](https://github.com/Brightspace/D2L.Hypermedia.Siren/issues/39)
- Enforced type constraints in the constructor